### PR TITLE
第20回課題：GET及び更新・登録処理のREST化

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -3,20 +3,20 @@ package raisetech.StudentManagement.controller;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
+import org.springframework.http.ResponseEntity;
 import org.springframework.ui.Model;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 import raisetech.StudentManagement.controller.converter.StudentConverter;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentsCourses;
 import raisetech.StudentManagement.domain.StudentDetail;
 import raisetech.StudentManagement.service.StudentService;
 
-@Controller
+@RestController
 public class StudentController {
 
   private StudentService service;
@@ -29,11 +29,10 @@ public class StudentController {
   }
 
   @GetMapping("/studentsList")
-  public String getStudentsList(Model model) {
+  public List<StudentDetail> getStudentsList() {
     List<Student> students = service.searchStudentsList();
     List<StudentsCourses> studentsCourses = service.searchStudentsCourseList();
-    model.addAttribute("studentList", converter.convertStudentDetails(students, studentsCourses));
-    return "studentList";
+    return converter.convertStudentDetails(students, studentsCourses);
   }
 
   @GetMapping("/studentsCoursesList")
@@ -52,13 +51,9 @@ public class StudentController {
   }
 
   @PostMapping("/registerStudent")
-  public String registerStudent(@ModelAttribute StudentDetail studentDetail,
-      BindingResult result) {
-    if (result.hasErrors()) {
-      return "registerStudent";
-    }
+  public ResponseEntity<String> registerStudent(@RequestBody StudentDetail studentDetail) {
     service.registerStudent(studentDetail);
-    return "redirect:/studentsList";
+    return ResponseEntity.ok("正常に登録されました");
   }
 
   @GetMapping("/edit/{id}")
@@ -70,12 +65,8 @@ public class StudentController {
   }
 
   @PostMapping("/updateStudent")
-  public String updateStudent(@ModelAttribute StudentDetail studentDetail,
-      BindingResult result) {
-    if (result.hasErrors()) {
-      return "updateStudent";
-    }
+  public ResponseEntity<String> updateStudent(@RequestBody StudentDetail studentDetail) {
     service.updateStudentDetail(studentDetail);
-    return "redirect:/studentsList";
+    return ResponseEntity.ok("正常に更新されました");
   }
 }


### PR DESCRIPTION
74a65d781134ead92062eaf5287652e6e041914e
修正内容
・検索一覧表示、更新処理、登録処理のREST化
＜controller＞
下記のREST化
　検索一覧表示：@GetMapping("/studentsList")
　更新処理：@PostMapping("/updateStudent")
　登録処理：@PostMapping("/registerStudent")

補足：現状の登録処理は、生徒情報のみの登録も可の仕様になっています。
登録処理はstudentsCourses==null・studentsCourses.course==nullでは例外になるようなので、ポストマンでstudentsCourses[{course=""}]で指定し回避しています。
studentsCourses[{course=""}]で実行した場合、serviseで設定した処理条件に合致しないため、コース情報は登録されず生徒情報のみの登録となります。

ーーー　検索結果取得　ーーー
①送信結果Postoman画面
![image](https://github.com/user-attachments/assets/ab3da320-232b-4714-ba8f-984f98406ad6)

ーーー　更新処理　ーーー
②処理前SQL
![image](https://github.com/user-attachments/assets/438a196b-1572-468f-8512-e6ea51db4ef6)

③更新POST送信画面（Postomanの内容と送信結果）※"student_id = 4"の"nickname"を変更
![image](https://github.com/user-attachments/assets/db281656-1e1b-45c1-b3bb-cf988fe0ffec)

④更新後MySQL画面
![image](https://github.com/user-attachments/assets/46b4c98c-6f7a-43a9-8634-7c341d155217)

ーーー　登録処理　ーーー
⑤登録POST送信画面（Postomanの内容と送信結果）
![image](https://github.com/user-attachments/assets/57ceb885-5044-4269-9c30-08ad583032c1)

⑥登録後MySQL画面
![image](https://github.com/user-attachments/assets/d1e77326-a16d-48f6-a31a-02e6ab9daa0a)

⑦登録POST送信画面※コースも登録する場合
![image](https://github.com/user-attachments/assets/096aa23c-be5a-4100-b63a-9dfffe3adf21)

⑧登録後SQL画面
![image](https://github.com/user-attachments/assets/c0f8a397-74c0-44c6-8607-f30d8ab256f2)
