### PR TITLE
コース申込状況：CourseStatusの追加に伴うCRUD処理とテストの追加変更

### DIFF
--- a/src/main/java/raisetech/StudentManagement/StudentManagementApplication.java
+++ b/src/main/java/raisetech/StudentManagement/StudentManagementApplication.java
@@ -9,8 +9,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class StudentManagementApplication {
 
-
   public static void main(String[] args) {
     SpringApplication.run(StudentManagementApplication.class, args);
   }
+
 }

--- a/src/main/java/raisetech/StudentManagement/StudentManagementApplication.java
+++ b/src/main/java/raisetech/StudentManagement/StudentManagementApplication.java
@@ -14,4 +14,3 @@ public class StudentManagementApplication {
     SpringApplication.run(StudentManagementApplication.class, args);
   }
 }
-

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -78,7 +78,6 @@ public class StudentController {
       @ApiResponse(responseCode = "400", description = "バリデーションエラー",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  @JsonView(JsonViews.OnAll.class)
   @PostMapping("/registerStudent")
   public ResponseEntity<StudentDetail> registerStudentDetail(
       @Validated(OnRegisterStudent.class)

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -78,6 +78,7 @@ public class StudentController {
       @ApiResponse(responseCode = "400", description = "バリデーションエラー",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
+  @JsonView(JsonViews.OnAll.class)
   @PostMapping("/registerStudent")
   public ResponseEntity<StudentDetail> registerStudentDetail(
       @Validated(OnRegisterStudent.class)

--- a/src/main/java/raisetech/StudentManagement/data/CourseStatus.java
+++ b/src/main/java/raisetech/StudentManagement/data/CourseStatus.java
@@ -1,0 +1,68 @@
+package raisetech.StudentManagement.data;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import raisetech.StudentManagement.validation.StudentValidation.OnRegisterCourse;
+import raisetech.StudentManagement.validation.StudentValidation.OnRegisterStudent;
+import raisetech.StudentManagement.validation.StudentValidation.OnUpdate;
+import raisetech.StudentManagement.view.JsonViews;
+
+/**
+ * Entity Class: コース申込状況 (`courses_status`) テーブルのエンティティクラス。 受講コース情報の申込状況を管理し、
+ */
+@Schema(description = "コース申込状況")
+@Getter
+@Setter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+public class CourseStatus {
+
+  @Schema(description = "コース申込状況ID (主キー)", example = "1")
+  @JsonView(JsonViews.OnAll.class)
+  @NotNull(groups = OnUpdate.class, message = "更新時はコース申込状況IDが必須です。")
+  private Integer courseStatusId;
+
+  @Schema(description = "コースID (外部キー)", example = "1")
+  @JsonView(JsonViews.OnAll.class)
+  @NotNull(groups = OnUpdate.class, message = "更新時はコースIDが必須です。")
+  private Integer courseId;
+
+  @Schema(description = "申込状況", example = "本申込")
+  @JsonView({JsonViews.OnRegister.class, JsonViews.OnAll.class})
+  @NotEmpty(groups = OnUpdate.class, message = "申込状況は必須です。")
+  @Pattern(regexp = "仮申込|本申込|受講中|受講完了|キャンセル",
+      groups = OnUpdate.class,
+      message = "仮申込,本申込,受講中,受講完了,キャンセル のいずれかを入力してください")
+  private String status;
+
+  @Schema(description = "仮申込日", example = "2024-03-01")
+  @JsonView({JsonViews.OnRegister.class, JsonViews.OnAll.class})
+  @PastOrPresent(groups = OnUpdate.class,
+      message = "過去または現在の日付を入力してください。")
+  private LocalDate provisionalApplicationDate;
+
+  @Schema(description = "本申込日", example = "2024-03-10")
+  @JsonView({JsonViews.OnRegister.class, JsonViews.OnAll.class})
+  @PastOrPresent(groups = {OnRegisterStudent.class, OnRegisterCourse.class, OnUpdate.class},
+      message = "過去または現在の日付を入力してください。")
+  private LocalDate applicationDate;
+
+  @Schema(description = "キャンセル日", example = "2024-03-20")
+  @JsonView({JsonViews.OnRegister.class, JsonViews.OnAll.class})
+  @PastOrPresent(groups = OnUpdate.class,
+      message = "過去または現在の日付を入力してください。")
+  private LocalDate cancelDate;
+
+}
+

--- a/src/main/java/raisetech/StudentManagement/domain/CourseDetail.java
+++ b/src/main/java/raisetech/StudentManagement/domain/CourseDetail.java
@@ -1,0 +1,42 @@
+package raisetech.StudentManagement.domain;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import raisetech.StudentManagement.data.CourseStatus;
+import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.validation.StudentValidation.OnRegisterStudent;
+import raisetech.StudentManagement.validation.StudentValidation.OnUpdate;
+import raisetech.StudentManagement.view.JsonViews;
+
+
+/**
+ * domain:受講コース詳細情報を表すクラスです。 受講コース情報 (`StudentCourse`) と受講コース申込み状況 (`CourseStatus`) で構成されます。
+ */
+@Schema(description = "受講コース詳細情報")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CourseDetail {
+
+  @Schema(description = "受講コース情報", requiredMode = Schema.RequiredMode.REQUIRED)
+  @JsonView({JsonViews.OnRegister.class, JsonViews.OnAll.class})
+  @Valid
+  @NotNull(groups = {OnRegisterStudent.class, OnUpdate.class},
+      message = "受講コース情報は必須です。")
+  private StudentCourse studentCourse;
+
+  @Schema(description = "コース申込み状況")
+  @JsonView({JsonViews.OnRegister.class, JsonViews.OnAll.class})
+  @Null(groups = OnRegisterStudent.class, message = "コース申込み状況は不要です。")
+  @NotNull(groups = OnUpdate.class, message = "コース申込み状況は必須です。")
+  @Valid
+  private CourseStatus courseStatus;
+}

--- a/src/main/java/raisetech/StudentManagement/domain/StudentDetail.java
+++ b/src/main/java/raisetech/StudentManagement/domain/StudentDetail.java
@@ -7,9 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.validation.StudentValidation.OnRegisterStudent;
 import raisetech.StudentManagement.validation.StudentValidation.OnUpdate;
@@ -19,8 +17,6 @@ import raisetech.StudentManagement.view.JsonViews;
  * domain:受講生詳細情報を表すクラスです。 受講生情報 (`Student`) と受講コース情報 (`StudentCourse`) で構成されます。
  */
 @Schema(description = "受講生詳細情報")
-@Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Data

--- a/src/main/java/raisetech/StudentManagement/domain/StudentDetail.java
+++ b/src/main/java/raisetech/StudentManagement/domain/StudentDetail.java
@@ -6,11 +6,11 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import raisetech.StudentManagement.data.Student;
-import raisetech.StudentManagement.data.StudentCourse;
 import raisetech.StudentManagement.validation.StudentValidation.OnRegisterStudent;
 import raisetech.StudentManagement.validation.StudentValidation.OnUpdate;
 import raisetech.StudentManagement.view.JsonViews;
@@ -23,6 +23,7 @@ import raisetech.StudentManagement.view.JsonViews;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Data
 public class StudentDetail {
 
   @Schema(description = "受講生の基本情報", requiredMode = Schema.RequiredMode.REQUIRED)
@@ -31,10 +32,10 @@ public class StudentDetail {
   @NotNull(groups = {OnRegisterStudent.class, OnUpdate.class}, message = "受講生情報は必須です。")
   private Student student;
 
-  @Schema(description = "受講コース情報のリスト")
+  @Schema(description = "受講コース詳細情報のリスト")
   @JsonView({JsonViews.OnRegister.class, JsonViews.OnAll.class})
   @Valid
-  private List<StudentCourse> studentCourseList;
+  private List<CourseDetail> courseDetailList;
 
 }
 

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -2,6 +2,7 @@ package raisetech.StudentManagement.repository;
 
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
+import raisetech.StudentManagement.data.CourseStatus;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
 
@@ -27,6 +28,13 @@ public interface StudentRepository {
   List<StudentCourse> searchStudentsCourses();
 
   /**
+   * 受講コースの申込状況の一覧を取得します。
+   *
+   * @return 受講コースの申込状況の一覧(全件)
+   */
+  List<CourseStatus> searchCoursesStatus();
+
+  /**
    * 指定された `studentId` に紐づく受講生情報を取得します。
    *
    * @param studentId 受講生ID
@@ -43,6 +51,14 @@ public interface StudentRepository {
   List<StudentCourse> searchStudentCoursesByStudentId(Integer studentId);
 
   /**
+   * 指定された `courseId` に紐づく受講コース情報を取得します。
+   *
+   * @param courseIdList 受講生ID
+   * @return zyy高コースIDと紐づく全ての受講コース情報を取得
+   */
+  List<CourseStatus> searchCourseStatusByCourseIdList(List<Integer> courseIdList);
+
+  /**
    * 受講生情報を新規登録します。 student_idは自動採番されます。
    *
    * @param student 登録する受講生情報
@@ -57,6 +73,13 @@ public interface StudentRepository {
   void registerStudentCourse(StudentCourse studentsCourses);
 
   /**
+   * 受講コース情報を新規登録します。 course_status_idは自動採番されます。
+   *
+   * @param courseStatus 登録する受講コース情報
+   */
+  void registerCourseStatus(CourseStatus courseStatus);
+
+  /**
    * 指定された `studentId` の受講生情報を更新します。
    *
    * @param student 更新する受講生情報
@@ -69,4 +92,11 @@ public interface StudentRepository {
    * @param studentCourse 更新する受講コース情報
    */
   void updateStudentCourse(StudentCourse studentCourse);
+
+  /**
+   * 指定された `courseId` の受講コース情報を更新します。
+   *
+   * @param CourseStatus 更新する受講コース情報
+   */
+  void updateCourseStatus(CourseStatus CourseStatus);
 }

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -2,14 +2,19 @@ package raisetech.StudentManagement.service;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
+import raisetech.StudentManagement.data.CourseStatus;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.domain.CourseDetail;
 import raisetech.StudentManagement.domain.StudentDetail;
 import raisetech.StudentManagement.repository.StudentRepository;
 import raisetech.StudentManagement.service.converter.StudentConverter;
@@ -30,32 +35,35 @@ public class StudentService {
   }
 
   /**
-   * 受講生及び受講生に紐づくコース情報(受講生詳細情報)の一覧を取得します。 除外対象:キャンセル扱い（`isDeleted=true`）の受講生は除外されます。
+   * 受講生及び受講生に紐づくコース詳細情報(受講生詳細情報)の一覧を取得します。 除外対象:キャンセル扱い（`student.isDeleted=true`）の受講生は除外されます。
    *
    * @return 受講生詳細情報の一覧(キャンセル扱いの受講生の受講生詳細情報を除く)
    */
   public List<StudentDetail> getStudentDetailList() {
     List<Student> studentsList = repository.searchStudents();
     List<StudentCourse> studentsCoursesList = repository.searchStudentsCourses();
-    return converter.convertStudentDetailList(studentsList, studentsCoursesList);
+    List<CourseStatus> courseStatusList = repository.searchCoursesStatus();
+    List<CourseDetail> courseDetailList = converter.convertCourseDetailList(studentsCoursesList,
+        courseStatusList);
+    return converter.convertStudentDetailList(studentsList, courseDetailList);
   }
 
   /**
-   * 指定された`studentId` に紐づく受講生及び受講コース情報(受講生詳細情報)を取得します。
+   * 指定された`studentId` に紐づく受講生及び受講コース詳細情報(受講生詳細情報)を取得します。
    *
    * @param studentId 受講生ID
    * @return 受講生詳細情報取得(受講生1名分)
    */
   public StudentDetail getStudentDetail(Integer studentId) {
     Student student = repository.searchStudentByStudentId(studentId);
-    List<StudentCourse> studentCourses = repository.searchStudentCoursesByStudentId(studentId);
+    List<StudentCourse> studentCourseList = repository.searchStudentCoursesByStudentId(studentId);
+    List<CourseDetail> courseDetailList = getCourseDetailList(studentCourseList);
 
     //studentIdに紐づくstudentが存在しない場合404エラーを返す。
     if (student == null) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, "受講生が見つかりませんでした");
     }
-
-    return new StudentDetail(student, studentCourses);
+    return new StudentDetail(student, courseDetailList);
   }
 
   /**
@@ -69,11 +77,11 @@ public class StudentService {
     repository.registerStudent(studentDetail.getStudent());
 
     Integer studentId = studentDetail.getStudent().getStudentId();
-    List<StudentCourse> registeredCourses = new ArrayList<>();
-    //受講コース情報がnullまたは空でないときのみコース登録処理を実行
-    if (studentDetail.getStudentCourseList() != null && !studentDetail.getStudentCourseList()
+    List<CourseDetail> registeredCourses = new ArrayList<>();
+    //コース詳細情報がnullでも空でもないときのみコース登録処理を実行
+    if (studentDetail.getCourseDetailList() != null && !studentDetail.getCourseDetailList()
         .isEmpty()) {
-      registeredCourses = registerStudentCourses(studentId, studentDetail.getStudentCourseList());
+      registeredCourses = registerCourseDetailList(studentId, studentDetail.getCourseDetailList());
     }
     return new StudentDetail(studentDetail.getStudent(), registeredCourses);
   }
@@ -81,8 +89,8 @@ public class StudentService {
   /**
    * 受講コースの新規登録を行います。 補足:登録にはコース名(course)が必須です。
    *
-   * @param studentId           登録対象の受講生ID
-   * @param studentsCoursesList 登録する受講コース情報のリスト
+   * @param studentId        登録対象の受講生ID
+   * @param courseDetailList 登録する受講コース情報のリスト
    * @return 登録対象となる受講コースの有無により下記いづれかを返します。
    * <ul>
    *   <li>なし:空のリスト</li>
@@ -90,38 +98,72 @@ public class StudentService {
    * </ul>
    */
   @Transactional
-  public List<StudentCourse> registerStudentCourses(Integer studentId,
-      List<StudentCourse> studentsCoursesList) {
-    //登録処理を実行(studentCourse.courseに入力がある場合のみ)
-    studentsCoursesList.forEach(studentCourse -> {
-      if (studentCourse.getCourse() != null && !studentCourse.getCourse().trim().isEmpty()) {
-        initStudentCourse(studentId, studentCourse);
-        repository.registerStudentCourse(studentCourse);
+  public List<CourseDetail> registerCourseDetailList(Integer studentId,
+      List<CourseDetail> courseDetailList) {
+    courseDetailList.forEach(courseDetail -> {
+      //登録処理を実行(studentCourse.courseに入力がある場合のみ)
+      if (courseDetail.getStudentCourse().getCourse() != null && !courseDetail.getStudentCourse()
+          .getCourse().trim().isEmpty()) {
+        courseDetail.getStudentCourse().setStudentId(studentId);
+        repository.registerStudentCourse(courseDetail.getStudentCourse());
+
+        //対になるCourseStatusを作成＆登録
+        Integer courseId = courseDetail.getStudentCourse().getCourseId();
+        CourseStatus courseStatus = initCourseStatus(courseId);
+        repository.registerCourseStatus(courseStatus);
       }
     });
-    return repository.searchStudentCoursesByStudentId(studentId);
+    List<StudentCourse> studentCourseList = repository.searchStudentCoursesByStudentId(studentId);
+
+    return getCourseDetailList(studentCourseList);
   }
 
-  static void initStudentCourse(Integer studentId, StudentCourse studentCourse) {
-    LocalDate today = LocalDate.now();
+  //StudentCourseに紐づくCourseStatusを作成し初期値を設定
+  static CourseStatus initCourseStatus(Integer courseId) {
+    CourseStatus courseStatus = new CourseStatus();
 
-    studentCourse.setStudentId(studentId);
-    studentCourse.setStartDate(today);
-    studentCourse.setEndDate(today.plusYears(1));
+    courseStatus.setStatus("仮申込");
+    courseStatus.setCourseId(courseId);
+    courseStatus.setProvisionalApplicationDate(LocalDate.now());
+
+    return courseStatus;
   }
 
   /**
    * 受講生及び受講コース情報の更新を行います。
+   *
+   * @param studentDetail 更新する受講生情報
    */
   @Transactional
   public void updateStudentDetail(StudentDetail studentDetail) {
     repository.updateStudent(studentDetail.getStudent());
 
-    if (studentDetail.getStudentCourseList() != null && !studentDetail.getStudentCourseList()
+    if (studentDetail.getCourseDetailList() != null && !studentDetail.getCourseDetailList()
         .isEmpty()) {
-      studentDetail.getStudentCourseList()
-          .forEach(studentCourse -> repository.updateStudentCourse(studentCourse));
+      studentDetail.getCourseDetailList()
+          .forEach(courseDetail -> {
+            repository.updateStudentCourse(courseDetail.getStudentCourse());
+            repository.updateCourseStatus(courseDetail.getCourseStatus());
+          });
     }
   }
+
+  /**
+   * 受講コース情報を受講詳細情報として取得する
+   *
+   * @param studentCourseList 取得したいコース詳細情報と関連する受講コース情報
+   * @return コース詳細情報のリスト
+   */
+  List<CourseDetail> getCourseDetailList(List<StudentCourse> studentCourseList) {
+    if (studentCourseList == null || Objects.requireNonNull(studentCourseList).isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<Integer> courseIdList = studentCourseList.stream()
+        .map(StudentCourse::getCourseId)
+        .collect(Collectors.toList());
+    List<CourseStatus> courseStatusList = repository.searchCourseStatusByCourseIdList(courseIdList);
+    return converter.convertCourseDetailList(studentCourseList, courseStatusList);
+  }
+
 }
 

--- a/src/main/java/raisetech/StudentManagement/service/converter/StudentConverter.java
+++ b/src/main/java/raisetech/StudentManagement/service/converter/StudentConverter.java
@@ -1,10 +1,14 @@
 package raisetech.StudentManagement.service.converter;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
+import raisetech.StudentManagement.data.CourseStatus;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.domain.CourseDetail;
 import raisetech.StudentManagement.domain.StudentDetail;
 
 /**
@@ -17,19 +21,36 @@ public class StudentConverter {
   /**
    * 受講生と受講コース情報から受講生詳細情報に変換します。
    *
-   * @param studentsList        受講生情報の一覧
-   * @param studentsCoursesList 受講コース情報の一覧
+   * @param studentsList     受講生情報の一覧
+   * @param courseDetailList 受講コース情報の一覧
    * @return 受講生詳細情報(受講生, 受講生に紐づく受講コース)からなる一覧
    */
   public List<StudentDetail> convertStudentDetailList(List<Student> studentsList,
-      List<StudentCourse> studentsCoursesList) {
+      List<CourseDetail> courseDetailList) {
 
     return studentsList.stream()
         .map(student -> new StudentDetail(student,
-            studentsCoursesList.stream()
+            courseDetailList.stream()
                 .filter(
-                    studentCourse -> student.getStudentId().equals(studentCourse.getStudentId()))
+                    courseDetail -> student.getStudentId()
+                        .equals(courseDetail.getStudentCourse().getStudentId()))
                 .collect(Collectors.toList())))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * @param studentsCoursesList
+   * @param courseStatusesList
+   * @return studentsCoursesListに基づくCourseDetailList
+   */
+  public List<CourseDetail> convertCourseDetailList(
+      List<StudentCourse> studentsCoursesList,
+      List<CourseStatus> courseStatusesList) {
+    Map<Integer, CourseStatus> statusMap = courseStatusesList.stream()
+        .collect(Collectors.toMap(CourseStatus::getCourseId, Function.identity()));
+
+    return studentsCoursesList.stream()
+        .map(course -> new CourseDetail(course, statusMap.get(course.getCourseId())))
         .collect(Collectors.toList());
   }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -13,4 +13,13 @@ INSERT INTO students_courses (student_id, course, start_date, end_date) VALUES
 (2, 'French',  '2024-11-05', '2025-07-04'),
 (4, 'Java',    '2024-10-20', '2025-03-19'),
 (4, 'Python',  '2024-03-04', '2025-04-20'),
-(5, 'English', '2024-12-05', '2025-07-04');
+(5, 'English', '2024-12-05', '2025-04-04');
+
+-- courses_status テーブル用データ
+INSERT INTO course_status (course_id, status, provisional_application_date, application_date, cancel_date) VALUES
+(1, '仮申込', '2024-09-15', NULL, NULL),
+(2, '本申込', '2024-10-01', '2024-10-15', NULL),
+(3, 'キャンセル', '2024-10-20', NULL, '2024-11-01'),
+(4, '受講中', '2024-09-30', '2024-10-10', NULL),
+(5, '仮申込', '2024-03-01', NULL, NULL),
+(6, '受講完了', '2024-11-20', '2024-12-01', NULL);

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -13,6 +13,11 @@
     SELECT * FROM students_courses
   </select>
 
+  <!-- 受講コース申込状況の一覧を取得 -->
+  <select id="searchCoursesStatus" resultType="raisetech.StudentManagement.data.CourseStatus">
+    SELECT * FROM course_status
+  </select>
+
   <!-- studentId に紐づく受講生情報を取得 -->
   <select id="searchStudentByStudentId" parameterType="java.lang.Integer"
     resultType="raisetech.StudentManagement.data.Student">
@@ -23,6 +28,17 @@
   <select id="searchStudentCoursesByStudentId" parameterType="java.lang.Integer"
     resultType="raisetech.StudentManagement.data.StudentCourse">
     SELECT * FROM students_courses WHERE student_id = #{studentId}
+  </select>
+
+  <!-- courseId に紐づく受講コース申込状況を取得 -->
+  <select id="searchCourseStatusByCourseIdList" parameterType="list"
+    resultType="raisetech.StudentManagement.data.CourseStatus">
+    SELECT *
+    FROM course_status
+    WHERE course_id IN
+    <foreach collection="list" item="id" open="(" separator="," close=")">
+      #{id}
+    </foreach>
   </select>
 
   <!-- 受講生情報を新規登録（student_id は自動採番） -->
@@ -39,6 +55,14 @@
     useGeneratedKeys="true" keyProperty="courseId">
     INSERT INTO students_courses (student_id, course, start_date, end_date)
     VALUES (#{studentId}, #{course}, #{startDate}, #{endDate})
+  </insert>
+
+  <!-- 受講コース申込状況を新規登録（course_status_id は自動採番） -->
+  <insert id="registerCourseStatus" parameterType="raisetech.StudentManagement.data.CourseStatus"
+    useGeneratedKeys="true" keyProperty="courseStatusId">
+    INSERT INTO course_status (course_id, status, provisional_application_date,
+    application_date,cancel_date)
+    VALUES (#{courseId},#{status}, #{provisionalApplicationDate}, #{applicationDate}, #{cancelDate})
   </insert>
 
   <!-- studentId に紐づく受講生情報を更新 -->
@@ -63,6 +87,17 @@
     start_date = #{startDate},
     end_date = #{endDate}
     WHERE course_id = #{courseId}
+  </update>
+
+  <!-- courseStatusId に紐づく受講コース情報を更新 -->
+  <update id="updateCourseStatus" parameterType="raisetech.StudentManagement.data.CourseStatus">
+    UPDATE course_status SET
+    course_id = #{courseId},
+    status = #{status},
+    provisional_application_date = #{provisionalApplicationDate},
+    application_date = #{applicationDate},
+    cancel_date = #{cancelDate}
+    WHERE course_status_id = #{courseStatusId}
   </update>
 
 </mapper>

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,4 +1,4 @@
-
+---Todo：設定内容の追加
 CREATE TABLE IF NOT EXISTS students (
   student_id INT PRIMARY KEY AUTO_INCREMENT,
   full_name VARCHAR(100) NOT NULL,
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS students (
   is_deleted BOOLEAN NOT NULL DEFAULT FALSE
 );
 
+---Todo：設定内容の追加
 CREATE TABLE IF NOT EXISTS students_courses (
   course_id INT PRIMARY KEY AUTO_INCREMENT,
   student_id INT NOT NULL,
@@ -19,4 +20,14 @@ CREATE TABLE IF NOT EXISTS students_courses (
   start_date DATE,
   end_date DATE,
   FOREIGN KEY (student_id) REFERENCES students(student_id)
+);
+
+CREATE TABLE course_status (
+  course_status_id INT PRIMARY KEY AUTO_INCREMENT,
+  course_id INT NOT NULL,
+  status VARCHAR(10) NOT NULL,
+  provisional_application_date DATE,
+  application_date DATE,
+  cancel_date DATE,
+  CONSTRAINT fk_course FOREIGN KEY (course_id) REFERENCES students_courses(course_id)
 );

--- a/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
@@ -1,19 +1,23 @@
 package raisetech.StudentManagement.controller;
 
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static raisetech.StudentManagement.testutil.TestDataFactory.createInitCourseStatus;
 import static raisetech.StudentManagement.testutil.TestDataFactory.createStudentCourseNormal;
 import static raisetech.StudentManagement.testutil.TestDataFactory.createStudentCourseNormalSimple;
 import static raisetech.StudentManagement.testutil.TestDataFactory.createStudentNormal;
 import static raisetech.StudentManagement.testutil.TestDataFactory.createStudentNormalSimple;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
 import java.util.List;
@@ -28,10 +32,13 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.server.ResponseStatusException;
+import raisetech.StudentManagement.data.CourseStatus;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.domain.CourseDetail;
 import raisetech.StudentManagement.domain.StudentDetail;
 import raisetech.StudentManagement.service.StudentService;
+import raisetech.StudentManagement.view.JsonViews;
 
 @WebMvcTest(StudentController.class)
 class StudentControllerTest {
@@ -49,20 +56,37 @@ class StudentControllerTest {
   private ArgumentCaptor<StudentDetail> studentDetailCaptor;
 
   private Integer studentId;
+  private Integer courseId1;
+  private Integer courseId2;
   private Student student;
   private StudentCourse course1;
   private StudentCourse course2;
-  private List<StudentCourse> studentCourseList;
+  private CourseStatus initCourseStatus1;
+  private CourseStatus initCourseStatus2;
+  private CourseDetail courseDetail1;
+  private CourseDetail courseDetail2;
+  private List<CourseDetail> courseDetailList;
   private StudentDetail studentDetail;
 
   // 各メソッドテスト用に、正常な学生情報とコース情報を持つ初期データを作成
   @BeforeEach
   void setUp() {
+    //受講生情報の準備
     studentId = 999;
     student = createStudentNormalSimple(studentId);
-    course1 = createStudentCourseNormalSimple(999, studentId);
-    course2 = createStudentCourseNormalSimple(9999, studentId);
-    studentCourseList = List.of(course1, course2);
+    //受講コース情報(リスト)の準備
+    courseId1 = 999;
+    courseId2 = 9999;
+    course1 = createStudentCourseNormalSimple(courseId1, studentId);
+    course2 = createStudentCourseNormalSimple(courseId2, studentId);
+    //受講コース申込状況(リスト)の準備
+    initCourseStatus1 = createInitCourseStatus(999, courseId1);
+    initCourseStatus2 = createInitCourseStatus(9999, courseId2);
+    //受講コース詳細情報(リスト)の準備
+    courseDetail1 = new CourseDetail(course1, initCourseStatus1);
+    courseDetail2 = new CourseDetail(course2, initCourseStatus2);
+    courseDetailList = List.of(courseDetail1, courseDetail2);
+    //受講コース情報の準備
     studentDetail = new StudentDetail(student, Collections.emptyList());
   }
 
@@ -79,7 +103,7 @@ class StudentControllerTest {
   @Test
   void 受講生詳細情報取得時に受講生情報と受講コース情報がJson形式で取得できること()
       throws Exception {
-    studentDetail.setStudentCourseList(studentCourseList);
+    studentDetail.setCourseDetailList(courseDetailList);
 
     when(service.getStudentDetail(studentId)).thenReturn(studentDetail);
 
@@ -88,11 +112,19 @@ class StudentControllerTest {
         .andExpect(jsonPath("$.student.studentId").value(studentId))
         .andExpect(jsonPath("$.student.fullName").value(student.getFullName()))
         .andExpect(jsonPath("$.student.mailAddress").value(student.getMailAddress()))
-        .andExpect(jsonPath("$.studentCourseList", hasSize(2)))
-        .andExpect(jsonPath("$.studentCourseList[0].courseId").value(course1.getCourseId()))
-        .andExpect(jsonPath("$.studentCourseList[0].course").value(course1.getCourse()))
-        .andExpect(jsonPath("$.studentCourseList[1].courseId").value(course2.getCourseId()))
-        .andExpect(jsonPath("$.studentCourseList[1].course").value(course2.getCourse()));
+        .andExpect(jsonPath("$.courseDetailList", hasSize(2)))
+        .andExpect(
+            jsonPath("$.courseDetailList[0].studentCourse.courseId").value(course1.getCourseId()))
+        .andExpect(
+            jsonPath("$.courseDetailList[0].studentCourse.course").value(course1.getCourse()))
+        .andExpect(jsonPath("$.courseDetailList[0].courseStatus.status").value(
+            initCourseStatus1.getStatus()))
+        .andExpect(
+            jsonPath("$.courseDetailList[1].studentCourse.courseId").value(course2.getCourseId()))
+        .andExpect(
+            jsonPath("$.courseDetailList[1].studentCourse.course").value(course2.getCourse()))
+        .andExpect(jsonPath("$.courseDetailList[1].courseStatus.status").value(
+            initCourseStatus2.getStatus()));
 
     verify(service, times(1)).getStudentDetail(studentId);
   }
@@ -108,7 +140,7 @@ class StudentControllerTest {
         .andExpect(jsonPath("$.student.studentId").value(studentId))
         .andExpect(jsonPath("$.student.fullName").value(student.getFullName()))
         .andExpect(jsonPath("$.student.mailAddress").value(student.getMailAddress()))
-        .andExpect(jsonPath("$.studentCourseList").isEmpty());
+        .andExpect(jsonPath("$.courseDetailList").isEmpty());
 
     verify(service, times(1)).getStudentDetail(studentId);
   }
@@ -128,18 +160,59 @@ class StudentControllerTest {
         .andExpect(jsonPath("$.error").value("受講生が見つかりませんでした"));
   }
 
-  //受講生登録処理
+  //受講生登録処理1
   @Test
-  void 受講生登録処理が実行できていること() throws Exception {
-    //登録処理の正常な
-    Student student = createStudentNormal(null);
-    StudentCourse studentCourse = createStudentCourseNormal(null, null);
-    StudentDetail studentDetail = new StudentDetail(student, List.of(studentCourse));
+  void 受講生登録処理_受講生と受講コース共に登録する場合_serviceが適切に実行されJsonで適切な返り値が返されていること()
+      throws Exception {
+    Student requestStudent = createStudentNormal(null);
+    StudentCourse requestStudentCourse = createStudentCourseNormal(null, null);
+    CourseDetail requestCourseDetail = new CourseDetail();
+    requestCourseDetail.setStudentCourse(requestStudentCourse);
+    requestCourseDetail.setCourseStatus(null);
+    StudentDetail requestStudentDetail = new StudentDetail(requestStudent,
+        List.of(requestCourseDetail));
+
+    when(service.registerStudentDetail(any())).thenReturn(
+        new StudentDetail(student, courseDetailList));
+
+    String jsonStudentDetail = toJsonWithView(requestStudentDetail, JsonViews.OnRegister.class);
 
     mockMvc.perform(post("/registerStudent")
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(studentDetail)))
-        .andExpect(status().isOk());
+            .content(jsonStudentDetail))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.student.studentId").isNumber())
+        .andExpect(jsonPath("$.student.fullName").value(requestStudent.getFullName()))
+        .andExpect(jsonPath("$.courseDetailList", hasSize(2)))
+        .andExpect(jsonPath("$.courseDetailList[0].studentCourse.courseId").isNumber())
+        .andExpect(jsonPath("$.courseDetailList[0].courseStatus.status").value("仮申込"))
+        .andExpect(jsonPath("$.courseDetailList[1].studentCourse.courseId").isNumber())
+        .andExpect(jsonPath("$.courseDetailList[1].courseStatus.status").value("仮申込"));
+    ;
+
+    verify(service, times(1)).registerStudentDetail(studentDetailCaptor.capture());
+  }
+
+  //受講生登録処理2
+  @Test
+  void 受講生登録処理_受講生のみ登録の場合_serviceが適切に実行されJsonで適切な返り値が返されていること()
+      throws Exception {
+    //登録処理の正常な
+    Student requestStudent = createStudentNormal(null);
+    StudentDetail requestStudentDetail = new StudentDetail(requestStudent, null);
+
+    when(service.registerStudentDetail(any())).thenReturn(
+        new StudentDetail(student, List.of())  // ← 登録後は空リストを返す想定
+    );
+
+    String jsonStudentDetail = toJsonWithView(requestStudentDetail, JsonViews.OnRegister.class);
+
+    mockMvc.perform(post("/registerStudent")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(jsonStudentDetail))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.student.studentId").isNumber())
+        .andExpect(jsonPath("$.courseDetailList").isEmpty());
 
     verify(service, times(1)).registerStudentDetail(studentDetailCaptor.capture());
   }
@@ -147,14 +220,25 @@ class StudentControllerTest {
   //受講生更新処理
   @Test
   void 受講生更新処理が実行できていること() throws Exception {
-    studentDetail.setStudentCourseList(studentCourseList);
+    studentDetail.setCourseDetailList(courseDetailList);
+
+    String jsonStudentDetail = toJsonWithView(studentDetail, JsonViews.OnAll.class);
 
     mockMvc.perform(put("/updateStudent")
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(studentDetail)))
-        .andExpect(status().isOk());
+            .content(jsonStudentDetail))
+        .andExpect(status().isOk())
+        .andExpect(content().string("正常に更新されました"));
 
     verify(service, times(1)).updateStudentDetail(studentDetailCaptor.capture());
   }
 
+  // 指定したビュークラスに従って、オブジェクトを JSON 文字列にシリアライズする。
+  // 他のテストに影響しないよう、ObjectMapper のコピーを使用。
+  private String toJsonWithView(Object obj, Class<?> viewClass) throws JsonProcessingException {
+    ObjectMapper localMapper = objectMapper.copy();
+    return localMapper
+        .setConfig(localMapper.getSerializationConfig().withView(viewClass))
+        .writeValueAsString(obj);
+  }
 }

--- a/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
@@ -188,7 +188,6 @@ class StudentControllerTest {
         .andExpect(jsonPath("$.courseDetailList[0].courseStatus.status").value("仮申込"))
         .andExpect(jsonPath("$.courseDetailList[1].studentCourse.courseId").isNumber())
         .andExpect(jsonPath("$.courseDetailList[1].courseStatus.status").value("仮申込"));
-    ;
 
     verify(service, times(1)).registerStudentDetail(studentDetailCaptor.capture());
   }

--- a/src/test/java/raisetech/StudentManagement/controller/validation/StudentControllerValidationTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/validation/StudentControllerValidationTest.java
@@ -4,11 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static raisetech.StudentManagement.testutil.TestDataFactory.createCourseStatusNormal;
+import static raisetech.StudentManagement.testutil.TestDataFactory.createInitCourseStatus;
+import static raisetech.StudentManagement.testutil.TestDataFactory.createStudentCourseNormal;
+import static raisetech.StudentManagement.testutil.TestDataFactory.createStudentNormal;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -22,11 +25,12 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import raisetech.StudentManagement.controller.StudentController;
+import raisetech.StudentManagement.data.CourseStatus;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.domain.CourseDetail;
 import raisetech.StudentManagement.domain.StudentDetail;
 import raisetech.StudentManagement.service.StudentService;
-import raisetech.StudentManagement.testutil.TestDataFactory;
 import raisetech.StudentManagement.validation.StudentValidation.OnRegisterStudent;
 import raisetech.StudentManagement.validation.StudentValidation.OnUpdate;
 
@@ -58,16 +62,18 @@ class StudentControllerValidationTest {
             .value("1 以上の値にしてください"));
   }
 
+  //Student1
   @Test
   void Studentクラスのバリデーション正常動作テスト() {
-    Student student = TestDataFactory.createStudentNormal(null);
+    Student registerNormalstudent = createStudentNormal(null);
 
-    Set<ConstraintViolation<Student>> violations = validator.validate(student,
+    Set<ConstraintViolation<Student>> violations = validator.validate(registerNormalstudent,
         OnRegisterStudent.class);
 
-    assertThat(violations.size()).isEqualTo(0);
+    assertThat(violations).isEmpty();
   }
 
+  //Student2
   @ParameterizedTest
   @MethodSource("studentValidationErrorCases")
   void Studentクラスのバリデーションエラー動作テスト(Student student, String errorResponse) {
@@ -81,7 +87,7 @@ class StudentControllerValidationTest {
         .containsOnly(errorResponse);
   }
 
-  //Studentのバリデーションエラーテストケース
+  //Student2のバリデーションエラーテストケース
   static Stream<Arguments> studentValidationErrorCases() {
     //studentId,fullName,mailAddress,sex,エラーmessage
     return Stream.of(
@@ -105,16 +111,17 @@ class StudentControllerValidationTest {
     );
   }
 
+  //StudentCourse1
   @Test
   void StudentCourseクラスのバリデーション正常動作テスト() {
-    StudentCourse studentCourse = TestDataFactory.createStudentCourseNormal(999, 999);
-
-    Set<ConstraintViolation<StudentCourse>> violations = validator.validate(studentCourse,
+    StudentCourse updateNormalCourse = createStudentCourseNormal(999, 999);
+    Set<ConstraintViolation<StudentCourse>> violations = validator.validate(updateNormalCourse,
         OnUpdate.class);
 
     assertThat(violations.size()).isEqualTo(0);
   }
 
+  //StudentCourse2
   @ParameterizedTest
   @MethodSource("studentCourseValidationErrorCases")
   void StudentCourse_バリデーションエラー動作テスト(StudentCourse studentCourse,
@@ -128,7 +135,7 @@ class StudentControllerValidationTest {
         .containsOnly(errorMessage);
   }
 
-  //StudentCourseのバリデーションエラーテストケース
+  //StudentCourse2のバリデーションエラーテストケース
   static Stream<Arguments> studentCourseValidationErrorCases() {
     //course,EndDate,エラーメッセージ
     return Stream.of(
@@ -138,12 +145,51 @@ class StudentControllerValidationTest {
     );
   }
 
+  //CourseStatus1
+  @Test
+  void CourseStatus_バリデーション正常動作テスト() {
+    CourseStatus updateNormalStatus = createCourseStatusNormal(999, 999);
+    Set<ConstraintViolation<CourseStatus>> violations = validator.validate(updateNormalStatus,
+        OnUpdate.class);
+
+    assertThat(violations).isEmpty();
+  }
+
+  //CourseStatus2
+  @ParameterizedTest
+  @MethodSource("courseStatusValidationErrorCases")
+  void CourseStatus_バリデーションエラー動作テスト(CourseStatus courseStatus, String errorMessage) {
+    Set<ConstraintViolation<CourseStatus>> violations = validator.validate(courseStatus,
+        OnUpdate.class);
+
+    assertThat(violations.size()).isEqualTo(1);
+    assertThat(violations)
+        .extracting(ConstraintViolation::getMessage)
+        .containsOnly(errorMessage);
+  }
+
+  //CourseStatus2のバリデーションエラーテストケース
+  static Stream<Arguments> courseStatusValidationErrorCases() {
+    return Stream.of(
+        Arguments.of(
+            ValidationTestDataFactory.createCourseStatusWithIncorrectStatus(999, 999),
+            "仮申込,本申込,受講中,受講完了,キャンセル のいずれかを入力してください"
+        ),
+        Arguments.of(
+            ValidationTestDataFactory.createCourseStatusWithFutureProvisionalDate(999, 999),
+            "過去または現在の日付を入力してください。"
+        )
+    );
+  }
+
+  //StudentDetail1
   @ParameterizedTest
   @MethodSource("studentCourseValidationNormalCases")
-  void StudentDetail_バリデーション正常動作テスト(Student student, List<StudentCourse> courseList) {
+  void StudentDetail_バリデーション正常動作テスト(Student student,
+      List<CourseDetail> courseDetailList) {
     StudentDetail studentDetail = new StudentDetail();
     studentDetail.setStudent(student);
-    studentDetail.setStudentCourseList(courseList);
+    studentDetail.setCourseDetailList(courseDetailList);
 
     Set<ConstraintViolation<StudentDetail>> violations =
         validator.validate(studentDetail, OnRegisterStudent.class);
@@ -151,25 +197,27 @@ class StudentControllerValidationTest {
     assertThat(violations.size()).isEqualTo(0);
   }
 
-  //StudentDetailのバリデーション正常テストケース
+  //StudentDetail1のバリデーション正常テストケース
   static Stream<Arguments> studentCourseValidationNormalCases() {
-    Student validStudent = TestDataFactory.createStudentNormal(null);
-    StudentCourse studentCourse = TestDataFactory.createStudentCourseNormal(null, null);
+    Student normalStudent = createStudentNormal(null);
+    StudentCourse normalStudentCourse = createStudentCourseNormal(null, null);
+    CourseDetail normalCourseDetail = new CourseDetail(normalStudentCourse, null);
 
     return Stream.of(
-        Arguments.of(validStudent, null),
-        Arguments.of(validStudent, Collections.emptyList()),
-        Arguments.of(validStudent, List.of(studentCourse))
+        Arguments.of(normalStudent, null),
+        Arguments.of(normalStudent, List.of(normalCourseDetail))
     );
   }
 
+  //StudentDetail2
   @ParameterizedTest
   @MethodSource("studentDetailValidationErrorCases")
-  void StudentDetail_バリデーションエラー動作テスト(Student student, List<StudentCourse> courseList,
+  void StudentDetail_バリデーションエラー動作テスト_(Student student,
+      List<CourseDetail> courseDetailList,
       String errorMessage) {
     StudentDetail studentDetail = new StudentDetail();
     studentDetail.setStudent(student);
-    studentDetail.setStudentCourseList(courseList);
+    studentDetail.setCourseDetailList(courseDetailList);
 
     Set<ConstraintViolation<StudentDetail>> violations =
         validator.validate(studentDetail, OnRegisterStudent.class);
@@ -181,19 +229,69 @@ class StudentControllerValidationTest {
         .containsOnly(errorMessage);
   }
 
-  //StudentDetailのバリデーションエラーテストケース
+  //StudentDetail2のバリデーションエラーテストケース(個別validationの確認と@Valid連携確認)
   private static Stream<Arguments> studentDetailValidationErrorCases() {
+    Student normalStudent = createStudentNormal(null);
+    StudentCourse normalStudentCourse = createStudentCourseNormal(null, null);
+    CourseDetail normalCourseDetail = new CourseDetail(normalStudentCourse, null);
+
     return Stream.of(
         // studentがnull
-        Arguments.of(null, List.of(), "受講生情報は必須です。"),
+        Arguments.of(null, null, "受講生情報は必須です。"),
         // studentのfullNameがnull
         Arguments.of(ValidationTestDataFactory.createStudentForFullNameValidTest(null, null),
-            List.of(),
+            List.of(normalCourseDetail),
             "氏名は必須です。"),
-        // studentCourseのコース名がnull
-        Arguments.of(TestDataFactory.createStudentNormal(null),
-            List.of(ValidationTestDataFactory.createStudentCourseWithNoCourse(null, null)),
-            "コース名は必須です。")
+        // CourseDetailのstudentCourseが空
+        Arguments.of(normalStudent, List.of(new CourseDetail()), "受講コース情報は必須です。")
+    );
+  }
+
+  //CourseDetail1
+  @Test
+  void CourseDetail_バリデーション正常動作テスト() {
+    StudentCourse registerNormalCourse = createStudentCourseNormal(null, null);
+    CourseDetail courseDetail = new CourseDetail(registerNormalCourse, null);
+    Set<ConstraintViolation<CourseDetail>> violations =
+        validator.validate(courseDetail, OnRegisterStudent.class);
+
+    assertThat(violations).isEmpty();
+  }
+
+  //CourseDetail2
+  @ParameterizedTest
+  @MethodSource("courseDetailValidationErrorCases")
+  void CourseDetail_バリデーションエラー動作テスト(StudentCourse studentCourse,
+      CourseStatus courseStatus,
+      String errorMessage) {
+    CourseDetail courseDetail = new CourseDetail(studentCourse, courseStatus);
+
+    Set<ConstraintViolation<CourseDetail>> violations =
+        validator.validate(courseDetail, OnUpdate.class);
+
+    assertThat(violations.size()).isEqualTo(1);
+
+    assertThat(violations)
+        .extracting(ConstraintViolation::getMessage)
+        .containsOnly(errorMessage);
+  }
+
+  //CourseDetail2のバリデーションエラーテストケース(個別validationの確認と@Valid連携確認)
+  private static Stream<Arguments> courseDetailValidationErrorCases() {
+    StudentCourse updateNormalCourse = createStudentCourseNormal(999, 999);
+    CourseStatus updateCourseStatus = createInitCourseStatus(999, 999);
+    return Stream.of(
+        // studentがnull
+        Arguments.of(null, updateCourseStatus, "受講コース情報は必須です。"),
+        Arguments.of(updateNormalCourse, null, "コース申込み状況は必須です。"),
+        // studentのfullNameがnull
+        Arguments.of(ValidationTestDataFactory.createStudentCourseWithNoCourse(999, 999),
+            updateCourseStatus,
+            "コース名は必須です。"),
+        // CourseDetailのstudentCourseが空
+        Arguments.of(updateNormalCourse,
+            ValidationTestDataFactory.createCourseStatusWithFutureProvisionalDate(999, 999),
+            "過去または現在の日付を入力してください。")
     );
   }
 }

--- a/src/test/java/raisetech/StudentManagement/controller/validation/ValidationTestDataFactory.java
+++ b/src/test/java/raisetech/StudentManagement/controller/validation/ValidationTestDataFactory.java
@@ -1,9 +1,11 @@
 package raisetech.StudentManagement.controller.validation;
 
+import static raisetech.StudentManagement.testutil.TestDataFactory.createCourseStatusNormal;
 import static raisetech.StudentManagement.testutil.TestDataFactory.createStudentCourseNormal;
 import static raisetech.StudentManagement.testutil.TestDataFactory.createStudentNormal;
 
 import java.time.LocalDate;
+import raisetech.StudentManagement.data.CourseStatus;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
 
@@ -43,5 +45,21 @@ public class ValidationTestDataFactory {
     StudentCourse studentCourse = createStudentCourseNormal(courseId, studentId);
     studentCourse.setEndDate(LocalDate.of(2023, 12, 31));
     return studentCourse;
+  }
+
+  // パターン外のstatus
+  public static CourseStatus createCourseStatusWithIncorrectStatus(Integer courseStatusId,
+      Integer courseId) {
+    CourseStatus courseStatus = createCourseStatusNormal(courseStatusId, courseId);
+    courseStatus.setStatus("申込");
+    return courseStatus;
+  }
+
+  // 過去または現在以外（未来日）の provisionalApplicationDate を設定
+  public static CourseStatus createCourseStatusWithFutureProvisionalDate(Integer courseStatusId,
+      Integer courseId) {
+    CourseStatus courseStatus = createCourseStatusNormal(courseStatusId, courseId);
+    courseStatus.setProvisionalApplicationDate(LocalDate.now().plusDays(1));
+    return courseStatus;
   }
 }

--- a/src/test/java/raisetech/StudentManagement/repository/StudentRepositoryTest.java
+++ b/src/test/java/raisetech/StudentManagement/repository/StudentRepositoryTest.java
@@ -4,12 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static raisetech.StudentManagement.testutil.TestDataFactory.createStudentCourseNormal;
 import static raisetech.StudentManagement.testutil.TestDataFactory.createStudentNormal;
 
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
+import raisetech.StudentManagement.data.CourseStatus;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.testutil.TestDataFactory;
 
 @MybatisTest
 class StudentRepositoryTest {
@@ -29,7 +32,7 @@ class StudentRepositoryTest {
   void キャンセル扱いの受講生は検索結果に含まれないこと() {
     List<Student> actual = sut.searchStudents();
     boolean containsDeleted = actual.stream()
-        .anyMatch(student -> student.getStudentId() == 4); // ID=4はis_deleted=true
+        .anyMatch(student -> student.getStudentId() == 4);
     assertThat(containsDeleted).isFalse();
   }
 
@@ -37,6 +40,13 @@ class StudentRepositoryTest {
   @Test
   void 受講コース情報の全件を検索できること() {
     List<StudentCourse> actual = sut.searchStudentsCourses();
+    assertThat(actual.size()).isEqualTo(6);
+  }
+
+  //受講コース情報一覧検索
+  @Test
+  void 全件取得でcourse_statusが全て取得できること() {
+    List<CourseStatus> actual = sut.searchCoursesStatus();
     assertThat(actual.size()).isEqualTo(6);
   }
 
@@ -71,6 +81,23 @@ class StudentRepositoryTest {
   @Test
   void 存在しないstudentIdでは受講コース情報が0件になること() {
     List<StudentCourse> actual = sut.searchStudentCoursesByStudentId(999);
+    assertThat(actual).isEmpty();
+  }
+
+  //CourseIdに紐づく受講コース情報検索①
+  @Test
+  void courseIdのリストに紐づけられるcourse_statusが検索できること() {
+    List<CourseStatus> actual = sut.searchCourseStatusByCourseIdList(List.of(1, 3, 5));
+    assertThat(actual.size()).isEqualTo(3);
+    assertThat(actual)
+        .extracting(CourseStatus::getCourseId)
+        .containsExactlyInAnyOrder(1, 3, 5);
+  }
+
+  //CourseIdに紐づく受講コース情報検索②
+  @Test
+  void courseIdのリストに存在しないIDを指定した場合はcourse_statusが0件になること() {
+    List<CourseStatus> actual = sut.searchCourseStatusByCourseIdList(List.of(999, 1000));
     assertThat(actual).isEmpty();
   }
 
@@ -120,6 +147,31 @@ class StudentRepositoryTest {
         .containsExactly(2, "Java");
   }
 
+  @Test
+  void コース申込状況を新規登録できること() {
+    LocalDate today = LocalDate.now();
+    CourseStatus courseStatus = TestDataFactory.createInitCourseStatus(null, 2);
+
+    sut.registerCourseStatus(courseStatus);
+
+    // courseStatusIdの発行確認
+    assertThat(courseStatus.getCourseStatusId()).isNotNull();
+
+    // IDが割り当てられたことを前提に検索・内容を検証
+    CourseStatus actual = sut.searchCoursesStatus().stream()
+        .filter(cs -> cs.getCourseStatusId().equals(courseStatus.getCourseStatusId()))
+        .findFirst()
+        .orElseThrow();
+
+    assertThat(actual)
+        .extracting(
+            CourseStatus::getCourseId,
+            CourseStatus::getStatus,
+            CourseStatus::getProvisionalApplicationDate
+        )
+        .containsExactly(2, "仮申込", today);
+  }
+
   //受講生更新処理
   @Test
   void 受講生情報の更新が行えること() {
@@ -164,5 +216,39 @@ class StudentRepositoryTest {
             StudentCourse::getEndDate
         )
         .containsExactly(2, "Chinese", course.getEndDate());
+  }
+
+  @Test
+  void 受講コース申込状況の更新が行えること() {
+    CourseStatus courseStatus = sut.searchCoursesStatus().stream()
+        .filter(cs -> cs.getCourseStatusId().equals(2))
+        .findFirst()
+        .orElseThrow();
+
+    courseStatus.setStatus("受講完了");
+    courseStatus.setCancelDate(LocalDate.of(2025, 4, 15));
+    courseStatus.setApplicationDate(LocalDate.of(2025, 1, 15));
+
+    sut.updateCourseStatus(courseStatus);
+
+    // 更新後のデータを再取得して検証
+    CourseStatus actual = sut.searchCoursesStatus().stream()
+        .filter(cs -> cs.getCourseStatusId().equals(2))
+        .findFirst()
+        .orElseThrow();
+
+    assertThat(actual)
+        .extracting(
+            CourseStatus::getCourseId,
+            CourseStatus::getStatus,
+            CourseStatus::getApplicationDate,
+            CourseStatus::getCancelDate
+        )
+        .containsExactly(
+            courseStatus.getCourseId(),
+            "受講完了",
+            LocalDate.of(2025, 1, 15),
+            LocalDate.of(2025, 4, 15)
+        );
   }
 }

--- a/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
@@ -6,16 +6,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static raisetech.StudentManagement.testutil.TestDataFactory.createInitCourseStatus;
 import static raisetech.StudentManagement.testutil.TestDataFactory.createStudentCourseNormalSimple;
 import static raisetech.StudentManagement.testutil.TestDataFactory.createStudentNormalSimple;
 
-import java.util.ArrayList;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
@@ -28,8 +27,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.server.ResponseStatusException;
+import raisetech.StudentManagement.data.CourseStatus;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.domain.CourseDetail;
 import raisetech.StudentManagement.domain.StudentDetail;
 import raisetech.StudentManagement.repository.StudentRepository;
 import raisetech.StudentManagement.service.converter.StudentConverter;
@@ -49,10 +50,19 @@ class StudentServiceTest {
   // テスト用の共通オブジェクト
   private Integer studentId;
   private Student student;
+  private Integer courseId1;
+  private Integer courseId2;
+  private List<Integer> courseIdList;
   private StudentCourse course1;
   private StudentCourse course2;
   private List<StudentCourse> studentCourseList;
+  private CourseStatus initStatus1;
+  private CourseStatus initStatus2;
+  private List<CourseStatus> courseStatusList;
   private StudentDetail studentDetail;
+  private CourseDetail courseDetail1;
+  private CourseDetail courseDetail2;
+  private List<CourseDetail> courseDetailList;
 
   @BeforeEach
   void setUp() {
@@ -64,12 +74,25 @@ class StudentServiceTest {
     student = createStudentNormalSimple(studentId);
 
     //受講コース情報(リスト)の準備
-    course1 = createStudentCourseNormalSimple(999, studentId);
-    course2 = createStudentCourseNormalSimple(9999, studentId);
+    courseId1 = 999;
+    courseId2 = 9999;
+    course1 = createStudentCourseNormalSimple(courseId1, studentId);
+    course2 = createStudentCourseNormalSimple(courseId2, studentId);
     studentCourseList = List.of(course1, course2);
+    courseIdList = List.of(courseId1, courseId2);
+
+    //受講コース申込状況(リスト)の準備
+    initStatus1 = createInitCourseStatus(999, courseId1);
+    initStatus2 = createInitCourseStatus(9999, courseId2);
+    courseStatusList = List.of(initStatus1, initStatus2);
+
+    //受講コース詳細情報(リスト)の準備
+    courseDetail1 = new CourseDetail(course1, initStatus1);
+    courseDetail2 = new CourseDetail(course2, initStatus2);
+    courseDetailList = List.of(courseDetail1, courseDetail2);
 
     //受講コース情報の準備
-    studentDetail = new StudentDetail(student, studentCourseList);
+    studentDetail = new StudentDetail(student, courseDetailList);
   }
 
   // テストデータを提供するメソッド
@@ -79,20 +102,47 @@ class StudentServiceTest {
 
   @Test
   void 受講生詳細情報の一覧検索_repositoryとconverterの処理が適切に呼び出せていること() {
-    List<Student> studentList = new ArrayList<>();
-    List<StudentCourse> studentCourseList = new ArrayList<>();
-    when(repository.searchStudents()).thenReturn(studentList);
+    when(repository.searchStudents()).thenReturn(List.of(student));
     when(repository.searchStudentsCourses()).thenReturn(studentCourseList);
+    when(repository.searchCoursesStatus()).thenReturn(courseStatusList);
+    when(converter.convertCourseDetailList(studentCourseList, courseStatusList)).thenReturn(
+        courseDetailList);
+    when(converter.convertStudentDetailList(List.of(student), courseDetailList)).thenReturn(
+        List.of(studentDetail));
 
     List<StudentDetail> actual = sut.getStudentDetailList();
 
     verify(repository, times(1)).searchStudents();
     verify(repository, times(1)).searchStudentsCourses();
-    verify(converter, times(1)).convertStudentDetailList(studentList, studentCourseList);
+    verify(repository, times(1)).searchCoursesStatus();
+    verify(converter, times(1)).convertCourseDetailList(studentCourseList, courseStatusList);
+    verify(converter, times(1)).convertStudentDetailList(List.of(student), courseDetailList);
   }
 
   @Test
-  void 個人の受講生詳細情報の検索_repositoryの処理の呼び出しとStudentDetailの生成が適切に行われていること() {
+  void 個人の受講生詳細情報の検索_StudentとCourseDetailがあるの場合_repositoryとconverterが適切に呼出され且つStudentDetailが適切に生成されていること() {
+    when(repository.searchStudentByStudentId(studentId)).thenReturn(student);
+    when(repository.searchStudentCoursesByStudentId(studentId)).thenReturn(studentCourseList);
+    when(repository.searchCourseStatusByCourseIdList(List.of(courseId1, courseId2))).thenReturn(
+        courseStatusList);
+    when(converter.convertCourseDetailList(studentCourseList, courseStatusList)).thenReturn(
+        courseDetailList);
+
+    StudentDetail actual = sut.getStudentDetail(studentId);
+
+    assertNotNull(actual);
+    assertEquals(studentDetail, actual);
+
+    verify(repository, times(1)).searchStudentByStudentId(studentId);
+    verify(repository, times(1)).searchStudentCoursesByStudentId(studentId);
+    //getCourseDetailListの呼び出し確認としてconvertCourseDetailList呼び出しを代用
+    verify(converter, times(1)).convertCourseDetailList(studentCourseList, courseStatusList);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideStudentCourseLists")
+  void 個人の受講生詳細情報の検索_StudentありでCourseDetailがnullまたはEmptyの場合_repositoryのみ適切に呼出され且つStudentDetailの空リストが生成されていること(
+      List<StudentCourse> studentCourseList) {
     when(repository.searchStudentByStudentId(studentId)).thenReturn(student);
     when(repository.searchStudentCoursesByStudentId(studentId)).thenReturn(studentCourseList);
 
@@ -100,10 +150,12 @@ class StudentServiceTest {
 
     assertNotNull(actual);
     assertEquals(student, actual.getStudent());
-    assertEquals(studentCourseList, actual.getStudentCourseList());
+    assertNotNull(actual.getCourseDetailList());
+    assertTrue(actual.getCourseDetailList().isEmpty());
 
     verify(repository, times(1)).searchStudentByStudentId(studentId);
     verify(repository, times(1)).searchStudentCoursesByStudentId(studentId);
+    verify(converter, never()).convertCourseDetailList(any(), any());
   }
 
   @Test
@@ -112,7 +164,6 @@ class StudentServiceTest {
     when(repository.searchStudentCoursesByStudentId(studentId)).thenReturn(Collections.emptyList());
 
     assertThrows(ResponseStatusException.class, () -> sut.getStudentDetail(studentId));
-
   }
 
   //受講生登録処理における受講コース情報の同時登録については受講コース情報登録処理(registerStudentCourses)の動作有無のみテスト
@@ -120,30 +171,38 @@ class StudentServiceTest {
   //受講生登録処理1
   @Test
   void 受講生詳細情報の登録処理_受講生情報と受講コース情報の同時登録時にrepository及びregisterStudentCoursesの処理が適切に呼び出せていること() {
-    doReturn(studentCourseList).when(repository).searchStudentCoursesByStudentId(studentId);
+    CourseDetail testCourseDetail1 = new CourseDetail(course1, null);
+    CourseDetail testCourseDetail2 = new CourseDetail(course2, null);
+    StudentDetail testStudentDetail = new StudentDetail(student,
+        List.of(testCourseDetail1, testCourseDetail2));
+    when(repository.searchStudentCoursesByStudentId(studentId)).thenReturn(studentCourseList);
+    when(repository.searchCourseStatusByCourseIdList(List.of(courseId1, courseId2))).thenReturn(
+        courseStatusList);
+    when(converter.convertCourseDetailList(studentCourseList, courseStatusList)).thenReturn(
+        courseDetailList);
 
-    StudentDetail actual = sut.registerStudentDetail(studentDetail);
+    StudentDetail actual = sut.registerStudentDetail(testStudentDetail);
 
     assertNotNull(actual);
-    assertEquals(student, actual.getStudent());
-    assertEquals(studentCourseList, actual.getStudentCourseList());
+    assertEquals(studentDetail, actual);
 
     verify(repository, times(1)).registerStudent(student);
+    //registerCourseDetailListが実行されたかを代替検証
     verify(repository, times(1)).searchStudentCoursesByStudentId(studentId);
   }
 
   //受講生登録処理2
   @ParameterizedTest
   @MethodSource("provideStudentCourseLists")
-  void 受講生情報のみの登録処理_コース情報がnullまたはempty_repositoryの処理が適切に呼び出され且つregisterStudentCoursesは呼び出されないこと(
-      List<StudentCourse> studentCourseList) {
-    StudentDetail studentDetail = new StudentDetail(student, studentCourseList);
+  void 受講生情報のみの登録処理_コース詳細情報がnullまたはEmpty_repositoryの処理が適切に呼び出され且つregisterStudentCoursesは呼び出されないこと(
+      List<CourseDetail> courseDetailList) {
+    StudentDetail studentDetail = new StudentDetail(student, courseDetailList);
 
     StudentDetail actual = sut.registerStudentDetail(studentDetail);
 
     assertNotNull(actual);
     assertEquals(student, actual.getStudent());
-    assertTrue(actual.getStudentCourseList().isEmpty());
+    assertTrue(actual.getCourseDetailList().isEmpty());
 
     verify(repository, times(1)).registerStudent(student);
     verify(repository, never()).searchStudentCoursesByStudentId(anyInt());
@@ -151,62 +210,88 @@ class StudentServiceTest {
 
   //受講コース情報登録処理
   @Test
-  void 受講コース情報の登録処理_コース情報の作成を行いかつrepositoryの処理が適切に呼び出せていること() {
+  void 受講コース情報の登録処理_コース情報の作成を行いかつrepositoryとgetCourseDetailListの処理が適切に呼び出せていること() {
     when(repository.searchStudentCoursesByStudentId(studentId)).thenReturn(studentCourseList);
+    when(repository.searchCourseStatusByCourseIdList(courseIdList)).thenReturn(
+        courseStatusList);
+    when(converter.convertCourseDetailList(studentCourseList, courseStatusList)).thenReturn(
+        courseDetailList);
 
-    List<StudentCourse> actual = sut.registerStudentCourses(studentId, studentCourseList);
+    List<CourseDetail> actual = sut.registerCourseDetailList(studentId, courseDetailList);
 
     assertNotNull(actual);
-    assertEquals(studentCourseList, actual);
+    assertEquals(courseDetailList, actual);
 
     verify(repository, times(studentCourseList.size())).registerStudentCourse(
         any(StudentCourse.class));
-
-    for (StudentCourse course : studentCourseList) {
-      assertEquals(studentId, course.getStudentId());
-      assertNotNull(course.getStartDate());
-      assertNotNull(course.getEndDate());
-      assertEquals(course.getStartDate().plusYears(1), course.getEndDate()); // 1年後になっているか
-    }
-
+    verify(repository, times(courseStatusList.size())).registerCourseStatus(
+        any(CourseStatus.class));
     verify(repository, times(1)).searchStudentCoursesByStudentId(studentId);
+    //getCourseDetailListの呼出確認をconverterの呼出で代替
+    verify(converter, times(1))
+        .convertCourseDetailList(studentCourseList, courseStatusList);
   }
 
   //受講コースの新規作成処理
   @Test
   void 登録するコース情報の作成_正常に受講コース情報を作成できていること() {
-    StudentService.initStudentCourse(studentId, course1);
+    LocalDate today = LocalDate.now();
+    CourseStatus courseStatus = StudentService.initCourseStatus(courseId1);
 
-    assertEquals(studentId, course1.getStudentId());
-    assertNotNull(course1.getStartDate());
-    assertNotNull(course1.getEndDate());
-    assertEquals(course1.getStartDate().plusYears(1), course1.getEndDate());
+    assertEquals(courseId1, courseStatus.getCourseId());
+    assertEquals(courseStatus.getStatus(), "仮申込");
+    assertEquals(today, courseStatus.getProvisionalApplicationDate());
   }
 
   //受講生詳細情報更新処理1
   @Test
-  void 受講生詳細情報の更新_受講生情報あり受講コースありの場合_repositoryの処理が適切に呼び出せていること() {
-    doNothing().when(repository).updateStudent(student);
-    doNothing().when(repository).updateStudentCourse(any(StudentCourse.class));
-
+  void 受講生詳細情報の更新_受講生情報ありコース詳細情報ありの場合_repositoryの処理が適切に呼び出せていること() {
     sut.updateStudentDetail(studentDetail);
 
     verify(repository, times(1)).updateStudent(student);
-    verify(repository, times(studentCourseList.size())).updateStudentCourse(
+    verify(repository, times(studentDetail.getCourseDetailList().size())).updateStudentCourse(
         any(StudentCourse.class));
+    verify(repository, times(studentDetail.getCourseDetailList().size())).updateCourseStatus(
+        any(CourseStatus.class));
   }
 
   //受講生詳細情報更新処理2
   @ParameterizedTest
   @MethodSource("provideStudentCourseLists")
-  void 受講生詳細情報の更新_受講生情報あり受講コースがnullまたはempty_repositoryの処理が適切に呼び出せていること(
-      List<StudentCourse> studentCourseList) {
-    StudentDetail studentDetail = new StudentDetail(student, studentCourseList);
+  void 受講生詳細情報の更新_受講生情報ありコース詳細情報がnullまたはEmpty_repositoryの処理が適切に呼び出せていること(
+      List<CourseDetail> courseDetailList) {
+    StudentDetail studentDetail = new StudentDetail(student, courseDetailList);
 
     sut.updateStudentDetail(studentDetail);
 
     verify(repository, times(1)).updateStudent(student);
     verify(repository, never()).updateStudentCourse(any(StudentCourse.class));
+    verify(repository, never()).updateCourseStatus(any(CourseStatus.class));
   }
 
+  @Test
+  void コース詳細情報作成_受講コース情報が存在する場合_repositoryとconverterが適正つに呼出されていること() {
+    when(repository.searchCourseStatusByCourseIdList(courseIdList)).thenReturn(courseStatusList);
+    when(converter.convertCourseDetailList(studentCourseList, courseStatusList)).thenReturn(
+        courseDetailList);
+
+    List<CourseDetail> actual = sut.getCourseDetailList(studentCourseList);
+
+    assertNotNull(actual);
+    assertEquals(courseDetailList, actual);
+
+    verify(repository, times(1)).searchCourseStatusByCourseIdList(
+        courseIdList);
+    verify(converter, times(1)).convertCourseDetailList(studentCourseList, courseStatusList);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideStudentCourseLists")
+  void コース詳細情報作成_受講コース情報リストにnullまたは空リストが渡された場合_空リストが返る(
+      List<StudentCourse> inputStudentCourseList) {
+    List<CourseDetail> actual = sut.getCourseDetailList(inputStudentCourseList);
+
+    assertNotNull(actual);
+    assertTrue(actual.isEmpty());
+  }
 }

--- a/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
@@ -270,7 +270,7 @@ class StudentServiceTest {
   }
 
   @Test
-  void コース詳細情報作成_受講コース情報が存在する場合_repositoryとconverterが適正つに呼出されていること() {
+  void コース詳細情報作成_受講コース情報が存在する場合_repositoryとconverterが適切に呼出されていること() {
     when(repository.searchCourseStatusByCourseIdList(courseIdList)).thenReturn(courseStatusList);
     when(converter.convertCourseDetailList(studentCourseList, courseStatusList)).thenReturn(
         courseDetailList);

--- a/src/test/java/raisetech/StudentManagement/service/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/converter/StudentConverterTest.java
@@ -1,5 +1,6 @@
 package raisetech.StudentManagement.service.converter;
 
+import static raisetech.StudentManagement.testutil.TestDataFactory.createInitCourseStatus;
 import static raisetech.StudentManagement.testutil.TestDataFactory.createStudentCourseNormalSimple;
 import static raisetech.StudentManagement.testutil.TestDataFactory.createStudentNormalSimple;
 
@@ -9,37 +10,84 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.List;
 import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
+import raisetech.StudentManagement.data.CourseStatus;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.domain.CourseDetail;
 import raisetech.StudentManagement.domain.StudentDetail;
 
 class StudentConverterTest {
 
+  private Student student1, student2, student3;
+  private StudentCourse course1, course2, course3;
+  private CourseStatus status1, status2, status3;
+  private CourseDetail courseDetail1, courseDetail2, courseDetail3;
+
+  @BeforeEach
+  void setUp() {
+    student1 = createStudentNormalSimple(999);
+    student2 = createStudentNormalSimple(1000);
+    student3 = createStudentNormalSimple(1001);
+
+    course1 = createStudentCourseNormalSimple(101, 999);
+    course2 = createStudentCourseNormalSimple(102, 999);
+    course3 = createStudentCourseNormalSimple(103, 1000);
+
+    status1 = createInitCourseStatus(101, 101);
+    status2 = createInitCourseStatus(102, 102);
+    status3 = createInitCourseStatus(103, 103);
+
+    courseDetail1 = new CourseDetail(course1, status1);
+    courseDetail2 = new CourseDetail(course2, status2);
+    courseDetail3 = new CourseDetail(course3, status3);
+  }
+
   @Test
-  void studentとStudentCourseの情報からJSON形式のstudentDetailに期待通りに変換されること()
+  void studentとCourseDetailの情報からJSON形式のstudentDetailに期待通りに変換されること()
       throws JsonProcessingException, JSONException {
-    Student student1 = createStudentNormalSimple(999);
-    Student student2 = createStudentNormalSimple(1000);
-    Student student3 = createStudentNormalSimple(1001);
-
-    StudentCourse course1 = createStudentCourseNormalSimple(101, 999);
-    StudentCourse course2 = createStudentCourseNormalSimple(102, 999);
-    StudentCourse course3 = createStudentCourseNormalSimple(103, 1000);
-
     List<Student> students = List.of(student1, student2, student3);
-    List<StudentCourse> courses = List.of(course1, course2, course3);
+    List<CourseDetail> courseDetails = List.of(courseDetail1, courseDetail2, courseDetail3);
 
     // Act（対象メソッドの呼び出し）
     StudentConverter sut = new StudentConverter();
-    List<StudentDetail> actual = sut.convertStudentDetailList(students, courses);
+    List<StudentDetail> actual = sut.convertStudentDetailList(students, courseDetails);
 
     // 期待されるオブジェクトを生成
-    StudentDetail expectedDetail1 = new StudentDetail(student1, List.of(course1, course2));
-    StudentDetail expectedDetail2 = new StudentDetail(student2, List.of(course3));
+    StudentDetail expectedDetail1 = new StudentDetail(student1,
+        List.of(courseDetail1, courseDetail2));
+    StudentDetail expectedDetail2 = new StudentDetail(student2, List.of(courseDetail3));
     StudentDetail expectedDetail3 = new StudentDetail(student3, List.of());
     List<StudentDetail> expected = List.of(expectedDetail1, expectedDetail2, expectedDetail3);
+    // JSON比較
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+    mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    String actualJson = mapper.writeValueAsString(actual);
+    String expectedJson = mapper.writeValueAsString(expected);
+
+    JSONAssert.assertEquals(expectedJson, actualJson, true);
+  }
+
+  @Test
+  void StudentCourseのListに紐づくCourseStatusを適切にJSON形式のCourseDetailに変換できていること()
+      throws JsonProcessingException, JSONException {
+    List<StudentCourse> studentCourses = List.of(course1, course2, course3);
+    List<CourseStatus> courseStatuses = List.of(status1, status2, status3);
+
+    // Act
+    StudentConverter sut = new StudentConverter();
+    List<CourseDetail> actual = sut.convertCourseDetailList(studentCourses, courseStatuses);
+
+    // Assert - 期待される結果を準備
+    List<CourseDetail> expected = List.of(
+        new CourseDetail(course1, status1),
+        new CourseDetail(course2, status2),
+        new CourseDetail(course3, status3)
+    );
 
     // JSON比較
     ObjectMapper mapper = new ObjectMapper();

--- a/src/test/java/raisetech/StudentManagement/testutil/TestDataFactory.java
+++ b/src/test/java/raisetech/StudentManagement/testutil/TestDataFactory.java
@@ -1,6 +1,7 @@
 package raisetech.StudentManagement.testutil;
 
 import java.time.LocalDate;
+import raisetech.StudentManagement.data.CourseStatus;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
 
@@ -41,6 +42,28 @@ public class TestDataFactory {
     return createStudentCourseNormalSimple(courseId, studentId).toBuilder()
         .startDate(LocalDate.now())
         .endDate(LocalDate.now().plusMonths(6))
+        .build();
+  }
+
+  //CourseStatus
+  //OnRegisterとOnUpdateで必要に応じてcourseStatusIdとcourseIdを設定
+  public static CourseStatus createInitCourseStatus(Integer courseStatusId,
+      Integer courseId) {
+    return CourseStatus.builder()
+        .courseStatusId(courseStatusId)
+        .courseId(courseId)
+        .status("仮申込")
+        .provisionalApplicationDate(LocalDate.now())
+        .build();
+  }
+
+  public static CourseStatus createCourseStatusNormal(Integer courseStatusId, Integer courseId) {
+    LocalDate provisionalApplicationDate = LocalDate.of(2025, 1, 1);
+    return createInitCourseStatus(courseStatusId, courseId).toBuilder()
+        .status("キャンセル")
+        .provisionalApplicationDate(provisionalApplicationDate)
+        .applicationDate(provisionalApplicationDate.plusDays(5))
+        .cancelDate(provisionalApplicationDate.plusMonths(2))
         .build();
   }
 }


### PR DESCRIPTION
fe3e8b71f4d5d01ee424e446bdda8d3f9a43c75c
追加
＜CourseStatus＞の追加：DBのcourse_statusと紐づくコース申込状況のエンティティclass
＜CourseDetail＞の追加：StudentCourse ＋CourseStatus からなる受講コース詳細情報を表すクラス
＜StudentDetail＞の変更：Student ＋ **CourseDetail** からなる受講性詳細情報を表すクラス
上記変更・追加に伴い
＜repository＞の追加：＜CourseStatus＞の検索・登録・更新処理の実装
＜controller＞＜service＞の変更：処理内容の追加と修正
＜converter＞の変更：StudentDetail変換処理の修正とCourseDetailへの変換処理の追加
各変更に伴うテストメソッドの追加・修正

追記：
・CourseStatusの項目やstatusの選択肢については、必要と思ったものを追加しました。
・CourseDetailはStudentCourse＋CourseStatusの1対1データになる(する)想定で作成しました。
　→StudentCourseを登録する際にアプリ内で初期値入りのCouseStatusを生成＆登録する形式にしました。
　→登録処理はStudentのみ登録可、Student+StudentCourseの同時登録可を想定しました。
　（但し、引数のCourseDetail.CourseStatusはNullである必要あり）
・controllerのテストでtoJsonWithViewメソッドを作成・使用し、クラス単位でのテストの一括実行時にメソッド間でmapperの状態が干渉しない様にしました。
　（テスト作成時にクラス単位のテスト実行でmapperがメソッド間で干渉し、単独実行では成功になるがクラス単位実行で失敗になるテストメソッドがあっため）

ーーDB course_statusの定義
![image](https://github.com/user-attachments/assets/7d738f83-ff4d-462e-8423-7da2b7299f11)

ーーテスト実行結果
コントコーラー
![image](https://github.com/user-attachments/assets/336f1d23-5a7d-4c93-98cc-b0e97022911d)

バリデーション
![image](https://github.com/user-attachments/assets/97e55c2d-7730-4006-92c9-dc3af0efb9e0)

サービス
![image](https://github.com/user-attachments/assets/6fc6c307-8ad0-47f6-a4f7-cdd76958a2a6)

リポジトリ
![image](https://github.com/user-attachments/assets/63d3e94f-06c0-4d0b-925e-37078505140a)

コンバーター
![image](https://github.com/user-attachments/assets/3676059f-4e48-48d9-81eb-86d414d0ea77)

ーーPostoman結果
〇全件検索結果
![image](https://github.com/user-attachments/assets/dcf69347-9865-4dbd-86e4-93420ed18304)

〇個人検索
![image](https://github.com/user-attachments/assets/4d4cf815-1b38-4711-84bf-eab8cf0a51e1)

〇登録処理
正常Request
![image](https://github.com/user-attachments/assets/f2855d74-3821-4d06-9a62-71190cca10b6)

正常Response
![image](https://github.com/user-attachments/assets/3afdd53d-b45f-46dd-9dae-90902a18c594)

異常　StudentCourse　Null
![image](https://github.com/user-attachments/assets/3b5a6e15-b80f-469c-9bbd-b98c02031643)

異常　CourseStatus　NotNull
![image](https://github.com/user-attachments/assets/0b2de82d-cec1-40a1-bf6b-8c4a635438ee)

〇更新処理
![image](https://github.com/user-attachments/assets/0b98f239-1ff9-47e0-ad38-b2585029160e)
