### PR TITLE
受講生詳細情報の条件検索機能追加

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -44,24 +44,13 @@ public class StudentController {
   }
 
   /**
-   * 受講生及び受講生に紐づくコース情報(受講生詳細情報)の一覧を取得します。 除外対象:キャンセル扱い（`isDeleted=true`）の受講生は除外されます。
-   *
-   * @return 受講生詳細情報の一覧(キャンセル扱いの受講生の受講生詳細情報を除く)
-   */
-  @Operation(summary = "全件検索", description = "受講生詳細情報の一覧を検索します。※キャンセル扱いの受講生は除外")
-  @GetMapping("/studentsList")
-  public List<StudentDetail> getStudentDetailList() {
-    return service.getStudentDetailList();
-  }
-
-  /**
    * 指定条件を満たす受講生詳細情報の一覧を取得します。 除外対象:キャンセル扱い（`isDeleted=true`）の受講生は検索条件に関わらず除外されます。
    *
    * @return 指定条件を満たす受講生詳細情報の一覧(条件によらずキャンセル扱いの受講生は含まれない)
    */
   @Operation(summary = "検索", description = "条件を満たす受講生詳細情報の一覧を検索します。※キャンセル扱いの受講生は除外")
-  @GetMapping("/studentsList/search")
-  public ResponseEntity<List<StudentDetail>> searchStudentDetailsByCriteria(
+  @GetMapping("/studentsList")
+  public ResponseEntity<List<StudentDetail>> getStudentDetailList(
       @Parameter(name = "criteria", description = "検索条件")
       @Valid StudentDetailSearchCriteria criteria) {
     List<StudentDetail> getStudentDetailList = service.searchStudentDetailListByCriteria(criteria);

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import raisetech.StudentManagement.domain.StudentDetail;
+import raisetech.StudentManagement.domain.criteria.StudentDetailSearchCriteria;
 import raisetech.StudentManagement.exception.ErrorResponse;
 import raisetech.StudentManagement.exception.TestException;
 import raisetech.StudentManagement.service.StudentService;
@@ -50,6 +52,20 @@ public class StudentController {
   @GetMapping("/studentsList")
   public List<StudentDetail> getStudentDetailList() {
     return service.getStudentDetailList();
+  }
+
+  /**
+   * 指定条件を満たす受講生詳細情報の一覧を取得します。 除外対象:キャンセル扱い（`isDeleted=true`）の受講生は検索条件に関わらず除外されます。
+   *
+   * @return 指定条件を満たす受講生詳細情報の一覧(条件によらずキャンセル扱いの受講生は含まれない)
+   */
+  @Operation(summary = "検索", description = "条件を満たす受講生詳細情報の一覧を検索します。※キャンセル扱いの受講生は除外")
+  @GetMapping("/studentsList/search")
+  public ResponseEntity<List<StudentDetail>> searchStudentDetailsByCriteria(
+      @Parameter(name = "criteria", description = "検索条件")
+      @Valid StudentDetailSearchCriteria criteria) {
+    List<StudentDetail> getStudentDetailList = service.searchStudentDetailListByCriteria(criteria);
+    return ResponseEntity.ok(getStudentDetailList);
   }
 
   /**

--- a/src/main/java/raisetech/StudentManagement/domain/criteria/StudentDetailSearchCriteria.java
+++ b/src/main/java/raisetech/StudentManagement/domain/criteria/StudentDetailSearchCriteria.java
@@ -1,0 +1,34 @@
+package raisetech.StudentManagement.domain.criteria;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Schema(description = "検索条件")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StudentDetailSearchCriteria {
+
+  @Schema(description = "受講生氏名", example = "山田_太郎")
+  private String fullName;
+
+  @Schema(description = "受講生氏名のフリガナ", example = "ヤマダ_タロウ")
+  private String fullNameKana;
+
+  @Schema(description = "居住エリア", example = "東京都_練馬区")
+  private String residenceArea;
+
+  @Schema(description = "受講コース名", example = "English")
+  private String course;
+
+  @Schema(description = "ステータス", example = "仮申込")
+  @Pattern(regexp = "仮申込|本申込|受講中|受講完了|キャンセル",
+      message = "仮申込,本申込,受講中,受講完了,キャンセル のいずれかを入力してください")
+  private String status;
+
+}

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -5,6 +5,7 @@ import org.apache.ibatis.annotations.Mapper;
 import raisetech.StudentManagement.data.CourseStatus;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.domain.criteria.StudentDetailSearchCriteria;
 
 /**
  * Repository: 受講生 (`students`) および受講コース (`students_courses`) テーブルへのアクセスを提供するリポジトリ。
@@ -33,6 +34,28 @@ public interface StudentRepository {
    * @return 受講コースの申込状況の一覧(全件)
    */
   List<CourseStatus> searchCoursesStatus();
+
+  /**
+   * 指定条件を満たす受講生情報を取得します。 除外対象:キャンセル扱い（`isDeleted=true`）の受講生は検索対象外。
+   *
+   * @return 受講生の条件検索結果一覧(キャンセル扱いの受講生は対象外)
+   */
+  List<Student> searchStudentsByCriteria(StudentDetailSearchCriteria criteria);
+
+  /**
+   * 指定条件を満たす受講生情報を取得します。 除外対象:キャンセル扱い（`isDeleted=true`）の受講生は検索対象外。
+   *
+   * @return 受講生の条件検索結果一覧(キャンセル扱いの受講生は対象外)
+   */
+  List<StudentCourse> searchStudentsCoursesByCriteria(StudentDetailSearchCriteria criteria);
+
+  /**
+   * 指定条件を満たす受講生情報を取得します。 除外対象:キャンセル扱い（`isDeleted=true`）の受講生は検索対象外。
+   *
+   * @return 受講生の条件検索結果一覧(キャンセル扱いの受講生は対象外)
+   */
+  List<CourseStatus> searchCourseStatusesByCriteria(StudentDetailSearchCriteria criteria);
+
 
   /**
    * 指定された `studentId` に紐づく受講生情報を取得します。
@@ -99,4 +122,5 @@ public interface StudentRepository {
    * @param CourseStatus 更新する受講コース情報
    */
   void updateCourseStatus(CourseStatus CourseStatus);
+
 }

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -15,27 +15,6 @@ import raisetech.StudentManagement.domain.criteria.StudentDetailSearchCriteria;
 public interface StudentRepository {
 
   /**
-   * 受講生情報の一覧を取得します。 除外対象:キャンセル扱い（`isDeleted=true`）の受講生は除外されます。
-   *
-   * @return 受講生の一覧(キャンセル扱いの受講生を除く)
-   */
-  List<Student> searchStudents();
-
-  /**
-   * 受講コース情報の一覧を取得します。
-   *
-   * @return 受講コースの一覧(全件)
-   */
-  List<StudentCourse> searchStudentsCourses();
-
-  /**
-   * 受講コースの申込状況の一覧を取得します。
-   *
-   * @return 受講コースの申込状況の一覧(全件)
-   */
-  List<CourseStatus> searchCoursesStatus();
-
-  /**
    * 指定条件を満たす受講生情報を取得します。 除外対象:キャンセル扱い（`isDeleted=true`）の受講生は検索対象外。
    *
    * @return 受講生の条件検索結果一覧(キャンセル扱いの受講生は対象外)
@@ -55,7 +34,6 @@ public interface StudentRepository {
    * @return 受講生の条件検索結果一覧(キャンセル扱いの受講生は対象外)
    */
   List<CourseStatus> searchCourseStatusesByCriteria(StudentDetailSearchCriteria criteria);
-
 
   /**
    * 指定された `studentId` に紐づく受講生情報を取得します。

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -16,6 +16,7 @@ import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
 import raisetech.StudentManagement.domain.CourseDetail;
 import raisetech.StudentManagement.domain.StudentDetail;
+import raisetech.StudentManagement.domain.criteria.StudentDetailSearchCriteria;
 import raisetech.StudentManagement.repository.StudentRepository;
 import raisetech.StudentManagement.service.converter.StudentConverter;
 
@@ -163,6 +164,37 @@ public class StudentService {
         .collect(Collectors.toList());
     List<CourseStatus> courseStatusList = repository.searchCourseStatusByCourseIdList(courseIdList);
     return converter.convertCourseDetailList(studentCourseList, courseStatusList);
+  }
+
+  /**
+   * 検索条件に一致する受講生詳細情報の一覧を取得します（キャンセル扱い（`student.isDeleted=true`）の受講生は除外されます。）
+   *
+   * @param criteria 検索条件
+   * @return 条件を満たす受講生詳細情報の一覧(キャンセル扱いの受講生の受講生詳細情報を除く)
+   */
+  public List<StudentDetail> searchStudentDetailListByCriteria(
+      StudentDetailSearchCriteria criteria) {
+    //DBの各テーブルに対し、対応するcriteriaで検索し一覧取得
+    List<StudentCourse> studentCoursesListByCriteria = repository.searchStudentsCoursesByCriteria(
+        criteria);
+    List<CourseStatus> courseStatusesListByCriteria = repository.searchCourseStatusesByCriteria(
+        criteria);
+    List<Student> studentListByCriteria = repository.searchStudentsByCriteria(criteria);
+
+    if (studentListByCriteria.isEmpty() || studentCoursesListByCriteria.isEmpty()
+        || courseStatusesListByCriteria.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<CourseDetail> courseDetailList = converter.combineStudentCourseWithCourseStatusByCourseId(
+        studentCoursesListByCriteria, courseStatusesListByCriteria);
+
+    if (courseDetailList.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    return converter.combineStudentsWithCourseDetailsByStudentId(
+        studentListByCriteria, courseDetailList);
   }
 
 }

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -36,17 +36,34 @@ public class StudentService {
   }
 
   /**
-   * 受講生及び受講生に紐づくコース詳細情報(受講生詳細情報)の一覧を取得します。 除外対象:キャンセル扱い（`student.isDeleted=true`）の受講生は除外されます。
+   * 検索条件に一致する受講生詳細情報の一覧を取得します（キャンセル扱い（`student.isDeleted=true`）の受講生は除外されます。）
    *
-   * @return 受講生詳細情報の一覧(キャンセル扱いの受講生の受講生詳細情報を除く)
+   * @param criteria 検索条件
+   * @return 条件を満たす受講生詳細情報の一覧(キャンセル扱いの受講生の受講生詳細情報を除く)
    */
-  public List<StudentDetail> getStudentDetailList() {
-    List<Student> studentsList = repository.searchStudents();
-    List<StudentCourse> studentsCoursesList = repository.searchStudentsCourses();
-    List<CourseStatus> courseStatusList = repository.searchCoursesStatus();
-    List<CourseDetail> courseDetailList = converter.convertCourseDetailList(studentsCoursesList,
-        courseStatusList);
-    return converter.convertStudentDetailList(studentsList, courseDetailList);
+  public List<StudentDetail> searchStudentDetailListByCriteria(
+      StudentDetailSearchCriteria criteria) {
+    //DBの各テーブルに対し、対応するcriteriaで検索し一覧取得
+    List<StudentCourse> studentCoursesListByCriteria = repository.searchStudentsCoursesByCriteria(
+        criteria);
+    List<CourseStatus> courseStatusesListByCriteria = repository.searchCourseStatusesByCriteria(
+        criteria);
+    List<Student> studentListByCriteria = repository.searchStudentsByCriteria(criteria);
+
+    if (studentListByCriteria.isEmpty() || studentCoursesListByCriteria.isEmpty()
+        || courseStatusesListByCriteria.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<CourseDetail> courseDetailList = converter.combineStudentCourseWithCourseStatusByCourseId(
+        studentCoursesListByCriteria, courseStatusesListByCriteria);
+
+    if (courseDetailList.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    return converter.combineStudentsWithCourseDetailsByStudentId(
+        studentListByCriteria, courseDetailList);
   }
 
   /**
@@ -164,37 +181,6 @@ public class StudentService {
         .collect(Collectors.toList());
     List<CourseStatus> courseStatusList = repository.searchCourseStatusByCourseIdList(courseIdList);
     return converter.convertCourseDetailList(studentCourseList, courseStatusList);
-  }
-
-  /**
-   * 検索条件に一致する受講生詳細情報の一覧を取得します（キャンセル扱い（`student.isDeleted=true`）の受講生は除外されます。）
-   *
-   * @param criteria 検索条件
-   * @return 条件を満たす受講生詳細情報の一覧(キャンセル扱いの受講生の受講生詳細情報を除く)
-   */
-  public List<StudentDetail> searchStudentDetailListByCriteria(
-      StudentDetailSearchCriteria criteria) {
-    //DBの各テーブルに対し、対応するcriteriaで検索し一覧取得
-    List<StudentCourse> studentCoursesListByCriteria = repository.searchStudentsCoursesByCriteria(
-        criteria);
-    List<CourseStatus> courseStatusesListByCriteria = repository.searchCourseStatusesByCriteria(
-        criteria);
-    List<Student> studentListByCriteria = repository.searchStudentsByCriteria(criteria);
-
-    if (studentListByCriteria.isEmpty() || studentCoursesListByCriteria.isEmpty()
-        || courseStatusesListByCriteria.isEmpty()) {
-      return Collections.emptyList();
-    }
-
-    List<CourseDetail> courseDetailList = converter.combineStudentCourseWithCourseStatusByCourseId(
-        studentCoursesListByCriteria, courseStatusesListByCriteria);
-
-    if (courseDetailList.isEmpty()) {
-      return Collections.emptyList();
-    }
-
-    return converter.combineStudentsWithCourseDetailsByStudentId(
-        studentListByCriteria, courseDetailList);
   }
 
 }

--- a/src/main/java/raisetech/StudentManagement/service/converter/StudentConverter.java
+++ b/src/main/java/raisetech/StudentManagement/service/converter/StudentConverter.java
@@ -39,6 +39,8 @@ public class StudentConverter {
   }
 
   /**
+   * 受講コース一覧に基づく受講生詳細情報に変換します。
+   *
    * @param studentsCoursesList
    * @param courseStatusesList
    * @return studentsCoursesListに基づくCourseDetailList
@@ -51,6 +53,44 @@ public class StudentConverter {
 
     return studentsCoursesList.stream()
         .map(course -> new CourseDetail(course, statusMap.get(course.getCourseId())))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * 受講コース一覧とコース申込状況一覧からどちらにも同じcourseIdがある組のみをCourseDetailに変換し一覧化ます。
+   *
+   * @param studentCourseList
+   * @param courseStatusList
+   * @return studentsCoursesListに基づくCourseDetailList
+   */
+  public List<CourseDetail> combineStudentCourseWithCourseStatusByCourseId(
+      List<StudentCourse> studentCourseList,
+      List<CourseStatus> courseStatusList) {
+    Map<Integer, CourseStatus> courseStatusMap = courseStatusList.stream()
+        .collect(Collectors.toMap(CourseStatus::getCourseId, Function.identity()));
+
+    return studentCourseList.stream()
+        .filter(studentCourse -> courseStatusMap.containsKey(studentCourse.getCourseId()))
+        .map(studentCourse -> new CourseDetail(studentCourse,
+            courseStatusMap.get(studentCourse.getCourseId())))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * 受講コース一覧とコース申込状況一覧からどちらにも同じcourseIdがある組のみをCourseDetailに変換し一覧化ます。
+   *
+   * @param studentList
+   * @param courseDetailList
+   * @return studentsCoursesListに基づくCourseDetailList
+   */
+  public List<StudentDetail> combineStudentsWithCourseDetailsByStudentId(List<Student> studentList,
+      List<CourseDetail> courseDetailList) {
+    Map<Integer, List<CourseDetail>> courseDetailMap = courseDetailList.stream()
+        .collect(Collectors.groupingBy(cd -> cd.getStudentCourse().getStudentId()));
+
+    return studentList.stream()
+        .filter(student -> courseDetailMap.containsKey(student.getStudentId()))
+        .map(student -> new StudentDetail(student, courseDetailMap.get(student.getStudentId())))
         .collect(Collectors.toList());
   }
 }

--- a/src/main/java/raisetech/StudentManagement/service/converter/StudentConverter.java
+++ b/src/main/java/raisetech/StudentManagement/service/converter/StudentConverter.java
@@ -19,26 +19,6 @@ import raisetech.StudentManagement.domain.StudentDetail;
 public class StudentConverter {
 
   /**
-   * 受講生と受講コース情報から受講生詳細情報に変換します。
-   *
-   * @param studentsList     受講生情報の一覧
-   * @param courseDetailList 受講コース情報の一覧
-   * @return 受講生詳細情報(受講生, 受講生に紐づく受講コース)からなる一覧
-   */
-  public List<StudentDetail> convertStudentDetailList(List<Student> studentsList,
-      List<CourseDetail> courseDetailList) {
-
-    return studentsList.stream()
-        .map(student -> new StudentDetail(student,
-            courseDetailList.stream()
-                .filter(
-                    courseDetail -> student.getStudentId()
-                        .equals(courseDetail.getStudentCourse().getStudentId()))
-                .collect(Collectors.toList())))
-        .collect(Collectors.toList());
-  }
-
-  /**
    * 受講コース一覧に基づく受講生詳細情報に変換します。
    *
    * @param studentsCoursesList

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -13,7 +13,9 @@ INSERT INTO students_courses (student_id, course, start_date, end_date) VALUES
 (2, 'French',  '2024-11-05', '2025-07-04'),
 (4, 'Java',    '2024-10-20', '2025-03-19'),
 (4, 'Python',  '2024-03-04', '2025-04-20'),
-(5, 'English', '2024-12-05', '2025-04-04');
+(5, 'English', '2024-12-05', '2025-04-04'),
+ -- 下記は対応するcourse_statusが未登録のdata
+(5, 'French',  '2024-12-10', '2025-07-09');
 
 -- courses_status テーブル用データ
 INSERT INTO course_status (course_id, status, provisional_application_date, application_date, cancel_date) VALUES

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,9 +2,9 @@
 INSERT INTO students (full_name, full_name_kana, nickname, mail_address, residence_area, age, sex, remark, is_deleted) VALUES
 ('田中_太郎', 'タナカ_タロウ', 'タロー', 'tanaka_taro@gmail.com', '東京_葛飾区', 25, 'Male', '', false),
 ('山田_花子', 'ヤマダ_ハナコ', 'ハナ', 'yamada_hanako@gmail.com', '千葉県_船橋市', 20, 'Female', '', false),
-('斎藤_肇', 'サイトウ_ハジメ', 'ハジメ', 'saito_hajime@example.com', '神奈川_横浜市', 35, 'Male', '', false),
-('鈴木_一郎', 'スズキ_イチロウ', 'イチロー', 'suzuki_ichi@example.com', '愛知_名古屋市', 28, 'Male', '', true),
-('小林_かおり', 'コバヤシ_カオリ', 'カオリ', 'kobayashi_kaori@example.com', '京都_京都市', 32, 'Female', NULL, false);
+('斎藤_太朗', 'サイトウ_タロウ', 'タロウ', 'saito_tarou@example.com', '神奈川_横浜市', 35, 'Male', '', false),
+('鈴木_一郎', 'スズキ_イチロウ', 'イチロー', 'suzuki_ichi@example.com', '京都_京都市', 28, 'Male', '', true),
+('小林_かおり', 'コバヤシ_カオリ', 'カオリ', 'kobayashi_kaori@example.com', '東京_立川市', 32, 'Female', NULL, false);
 
 -- students_courses テーブル用データ
 INSERT INTO students_courses (student_id, course, start_date, end_date) VALUES

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -3,21 +3,6 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="raisetech.StudentManagement.repository.StudentRepository">
 
-  <!-- 受講生情報の一覧を取得（キャンセル扱いの受講生は除外） -->
-  <select id="searchStudents" resultType="raisetech.StudentManagement.data.Student">
-    SELECT * FROM students WHERE is_deleted = false
-  </select>
-
-  <!-- 受講コース情報の一覧を取得 -->
-  <select id="searchStudentsCourses" resultType="raisetech.StudentManagement.data.StudentCourse">
-    SELECT * FROM students_courses
-  </select>
-
-  <!-- 受講コース申込状況の一覧を取得 -->
-  <select id="searchCoursesStatus" resultType="raisetech.StudentManagement.data.CourseStatus">
-    SELECT * FROM course_status
-  </select>
-
   <!-- 指定条件を満たす受講生情報の一覧を取得 -->
   <select id="searchStudentsByCriteria"
     parameterType="raisetech.StudentManagement.domain.criteria.StudentDetailSearchCriteria"

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -18,6 +18,49 @@
     SELECT * FROM course_status
   </select>
 
+  <!-- 指定条件を満たす受講生情報の一覧を取得 -->
+  <select id="searchStudentsByCriteria"
+    parameterType="raisetech.StudentManagement.domain.criteria.StudentDetailSearchCriteria"
+    resultType="raisetech.StudentManagement.data.Student">
+    SELECT * FROM students
+    <where>
+      is_deleted = false
+      <if test="fullName != null and fullName != ''">
+        AND full_name LIKE CONCAT('%', #{fullName}, '%')
+      </if>
+      <if test="fullNameKana != null and fullNameKana != ''">
+        AND full_name_kana LIKE CONCAT('%', #{fullNameKana}, '%')
+      </if>
+      <if test="residenceArea != null and residenceArea != ''">
+        AND residence_area LIKE CONCAT('%', #{residenceArea}, '%')
+      </if>
+    </where>
+  </select>
+
+  <!-- 指定条件を満たす受講コース情報の一覧を取得 -->
+  <select id="searchStudentsCoursesByCriteria"
+    parameterType="raisetech.StudentManagement.domain.criteria.StudentDetailSearchCriteria"
+    resultType="raisetech.StudentManagement.data.StudentCourse">
+    SELECT * FROM students_courses
+    <where>
+      <if test="course != null and course != ''">
+        AND course LIKE CONCAT('%', #{course}, '%')
+      </if>
+    </where>
+  </select>
+
+  <!-- 指定条件を満たすコース申込状況の一覧を取得 -->
+  <select id="searchCourseStatusesByCriteria"
+    parameterType="raisetech.StudentManagement.domain.criteria.StudentDetailSearchCriteria"
+    resultType="raisetech.StudentManagement.data.CourseStatus">
+    SELECT * FROM course_status
+    <where>
+      <if test="status != null and status != ''">
+        AND status LIKE CONCAT('%', #{status}, '%')
+      </if>
+    </where>
+  </select>
+
   <!-- studentId に紐づく受講生情報を取得 -->
   <select id="searchStudentByStudentId" parameterType="java.lang.Integer"
     resultType="raisetech.StudentManagement.data.Student">
@@ -33,8 +76,7 @@
   <!-- courseId に紐づく受講コース申込状況を取得 -->
   <select id="searchCourseStatusByCourseIdList" parameterType="list"
     resultType="raisetech.StudentManagement.data.CourseStatus">
-    SELECT *
-    FROM course_status
+    SELECT * FROM course_status
     WHERE course_id IN
     <foreach collection="list" item="id" open="(" separator="," close=")">
       #{id}

--- a/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
@@ -1,6 +1,7 @@
 package raisetech.StudentManagement.controller;
 
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -37,6 +38,7 @@ import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
 import raisetech.StudentManagement.domain.CourseDetail;
 import raisetech.StudentManagement.domain.StudentDetail;
+import raisetech.StudentManagement.domain.criteria.StudentDetailSearchCriteria;
 import raisetech.StudentManagement.service.StudentService;
 import raisetech.StudentManagement.view.JsonViews;
 
@@ -97,6 +99,51 @@ class StudentControllerTest {
         .andExpect(status().isOk());
 
     verify(service, times(1)).getStudentDetailList();
+  }
+
+  //指定条件を満たす受講生詳細情報の取得1/正常200
+  @Test
+  void 受講生詳細情報の条件指定検索で条件が適切に送られかつ検索結果がJson形式で取得できること()
+      throws Exception {
+    studentDetail.setCourseDetailList(courseDetailList);
+    List<StudentDetail> studentDetailList = List.of(studentDetail);
+
+    ArgumentCaptor<StudentDetailSearchCriteria> criteriaCaptor =
+        ArgumentCaptor.forClass(StudentDetailSearchCriteria.class);
+
+    when(service.searchStudentDetailListByCriteria(criteriaCaptor.capture()))
+        .thenReturn(studentDetailList);
+
+    mockMvc.perform(get("/studentsList/search")
+            .param("fullName", "森 一")
+            .param("course", "Java")
+            .param("status", "仮申込")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].student.studentId").value(student.getStudentId()))
+        .andExpect(jsonPath("$[0].student.fullName").value(student.getFullName()))
+        .andExpect(jsonPath("$[0].courseDetailList", hasSize(2)))
+        .andExpect(jsonPath("$[0].courseDetailList[0].studentCourse.courseId").value(
+            course1.getCourseId()))
+        .andExpect(
+            jsonPath("$[0].courseDetailList[0].studentCourse.course").value(course1.getCourse()))
+        .andExpect(jsonPath("$[0].courseDetailList[0].courseStatus.status").value(
+            initCourseStatus1.getStatus()))
+        .andExpect(jsonPath("$[0].courseDetailList[1].studentCourse.courseId").value(
+            course2.getCourseId()))
+        .andExpect(
+            jsonPath("$[0].courseDetailList[1].studentCourse.course").value(course2.getCourse()))
+        .andExpect(jsonPath("$[0].courseDetailList[1].courseStatus.status").value(
+            initCourseStatus2.getStatus()));
+
+    StudentDetailSearchCriteria capturedCriteria = criteriaCaptor.getValue();
+    assertEquals("森 一", capturedCriteria.getFullName());
+    assertEquals("Java", capturedCriteria.getCourse());
+    assertEquals("仮申込", capturedCriteria.getStatus());
+
+    verify(service, times(1)).searchStudentDetailListByCriteria(
+        any(StudentDetailSearchCriteria.class));
   }
 
   //個人の受講生詳細情報の取得1/正常200

--- a/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
@@ -92,15 +92,6 @@ class StudentControllerTest {
     studentDetail = new StudentDetail(student, Collections.emptyList());
   }
 
-  //受講生詳細情報一覧の取得1
-  @Test
-  void 受講生詳細の一覧検索が実行できていること() throws Exception {
-    mockMvc.perform(get("/studentsList"))
-        .andExpect(status().isOk());
-
-    verify(service, times(1)).getStudentDetailList();
-  }
-
   //指定条件を満たす受講生詳細情報の取得1/正常200
   @Test
   void 受講生詳細情報の条件指定検索で条件が適切に送られかつ検索結果がJson形式で取得できること()
@@ -114,7 +105,7 @@ class StudentControllerTest {
     when(service.searchStudentDetailListByCriteria(criteriaCaptor.capture()))
         .thenReturn(studentDetailList);
 
-    mockMvc.perform(get("/studentsList/search")
+    mockMvc.perform(get("/studentsList")
             .param("fullName", "森 一")
             .param("course", "Java")
             .param("status", "仮申込")

--- a/src/test/java/raisetech/StudentManagement/controller/validation/StudentControllerValidationTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/validation/StudentControllerValidationTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -30,6 +31,7 @@ import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
 import raisetech.StudentManagement.domain.CourseDetail;
 import raisetech.StudentManagement.domain.StudentDetail;
+import raisetech.StudentManagement.domain.criteria.StudentDetailSearchCriteria;
 import raisetech.StudentManagement.service.StudentService;
 import raisetech.StudentManagement.validation.StudentValidation.OnRegisterStudent;
 import raisetech.StudentManagement.validation.StudentValidation.OnUpdate;
@@ -294,4 +296,31 @@ class StudentControllerValidationTest {
             "過去または現在の日付を入力してください。")
     );
   }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"仮申込", "本申込", "受講中", "受講完了", "キャンセル"})
+  void 検索条件_バリデーション正常動作テスト(String status) {
+    StudentDetailSearchCriteria criteria = new StudentDetailSearchCriteria();
+    criteria.setStatus(status);
+
+    Set<ConstraintViolation<StudentDetailSearchCriteria>> violations = validator.validate(criteria);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void 検索条件_バリデーション異常動作テスト() {
+    StudentDetailSearchCriteria criteria = new StudentDetailSearchCriteria();
+    criteria.setStatus("仮申込み");
+
+    Set<ConstraintViolation<StudentDetailSearchCriteria>> violations = validator.validate(criteria);
+
+    assertThat(violations.size()).isEqualTo(1);
+
+    assertThat(violations)
+        .extracting(ConstraintViolation::getMessage)
+        .containsOnly("仮申込,本申込,受講中,受講完了,キャンセル のいずれかを入力してください");
+  }
+
+
 }

--- a/src/test/java/raisetech/StudentManagement/repository/StudentRepositoryTest.java
+++ b/src/test/java/raisetech/StudentManagement/repository/StudentRepositoryTest.java
@@ -6,12 +6,14 @@ import static raisetech.StudentManagement.testutil.TestDataFactory.createStudent
 
 import java.time.LocalDate;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import raisetech.StudentManagement.data.CourseStatus;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.domain.criteria.StudentDetailSearchCriteria;
 import raisetech.StudentManagement.testutil.TestDataFactory;
 
 @MybatisTest
@@ -19,6 +21,13 @@ class StudentRepositoryTest {
 
   @Autowired
   private StudentRepository sut;
+
+  private StudentDetailSearchCriteria criteria;
+
+  @BeforeEach
+  void setUp() {
+    criteria = new StudentDetailSearchCriteria();
+  }
 
   //受講生情報一覧検索①
   @Test
@@ -50,6 +59,101 @@ class StudentRepositoryTest {
     assertThat(actual.size()).isEqualTo(6);
   }
 
+  // 条件指定受講生検索1
+  @Test
+  void 条件指定検索_検索条件に氏名を指定して想定通り検索できること() {
+    criteria.setFullName("田");
+    List<Student> actual = sut.searchStudentsByCriteria(criteria);
+
+    assertThat(actual).hasSize(2);
+    assertThat(actual).allMatch(student -> student.getFullName().contains("田"));
+  }
+
+  // 条件指定受講生検索2
+  @Test
+  void 条件指定受講生検索_検索条件にカナ名を指定して想定通り検索できること() {
+    criteria.setFullNameKana("タロウ");
+    List<Student> actual = sut.searchStudentsByCriteria(criteria);
+
+    assertThat(actual).hasSize(2);
+    assertThat(actual).allMatch(student -> student.getFullNameKana().contains("タロウ"));
+  }
+
+  // 条件指定受講生検索3
+  @Test
+  void 条件指定受講生検索_検索条件に居住地を指定して想定通り検索できること() {
+    criteria.setResidenceArea("東京");
+    List<Student> actual = sut.searchStudentsByCriteria(criteria);
+
+    assertThat(actual).hasSize(2);
+    assertThat(actual).allMatch(student -> student.getResidenceArea().contains("東京"));
+  }
+
+  // 条件指定受講生検索4
+  @Test
+  void 条件指定受講生検索_検索条件に前3条件を指定して想定通り検索できること() {
+    criteria.setFullName("田");
+    criteria.setFullNameKana("タロウ");
+    criteria.setResidenceArea("東京");
+    List<Student> actual = sut.searchStudentsByCriteria(criteria);
+
+    assertThat(actual).hasSize(1);
+    assertThat(actual).allMatch(student -> student.getResidenceArea().contains("東京"));
+  }
+
+  //　条件指定受講生検索5
+  @Test
+  void 条件指定受講生検索_条件未指定で論理削除を除く全件取得できること() {
+    List<Student> actual = sut.searchStudentsByCriteria(criteria);
+    boolean containsDeleted = actual.stream()
+        .anyMatch(student -> student.getStudentId() == 4);
+    assertThat(containsDeleted).isFalse();
+  }
+
+  //　条件指定受講生検索6
+  @Test
+  void 条件指定受講生検索_条件を満たす受講生がいない場合に空リストが返ること() {
+    criteria.setFullName("佐々木");
+    List<Student> actual = sut.searchStudentsByCriteria(criteria);
+    assertThat(actual).isEmpty();
+  }
+
+  // 条件指定受講コース検索1
+  @Test
+  void 条件指定検索_検索条件にコース名を指定して想定通り検索できること() {
+    criteria.setCourse("English");
+    List<StudentCourse> actual = sut.searchStudentsCoursesByCriteria(criteria);
+
+    assertThat(actual).hasSize(2);
+    assertThat(actual).allMatch(student -> student.getCourse().contains("English"));
+  }
+
+  // 条件指定受講コース検索2
+  @Test
+  void 条件指定受講生検索_条件を満たす受講コースがいない場合に空リストが返ること() {
+    criteria.setCourse("Chinese");
+    List<StudentCourse> actual = sut.searchStudentsCoursesByCriteria(criteria);
+    assertThat(actual).isEmpty();
+  }
+
+  // 条件指定コース申込状況検索1
+  @Test
+  void 条件指定検索_検索条件に申込状況を指定して想定通り検索できること() {
+    criteria.setStatus("仮申込");
+    List<CourseStatus> actual = sut.searchCourseStatusesByCriteria(criteria);
+
+    assertThat(actual).hasSize(2);
+    assertThat(actual).allMatch(student -> student.getStatus().contains("仮申込"));
+  }
+
+  // 条件指定コース申込状況検索2
+  @Test
+  void 条件指定受講生検索_条件を満たす申込状況がいない場合に空リストが返ること() {
+    criteria.setStatus("Chinese");
+    List<CourseStatus> actual = sut.searchCourseStatusesByCriteria(criteria);
+    assertThat(actual).isEmpty();
+  }
+
   //StudentIdに基づく受講生情報検索①
   @Test
   void studentIdに基づく受講生情報の検索ができること() {
@@ -57,7 +161,6 @@ class StudentRepositoryTest {
     assertThat(actual)
         .extracting(Student::getFullName, Student::getFullNameKana, Student::getMailAddress)
         .containsExactly("山田_花子", "ヤマダ_ハナコ", "yamada_hanako@gmail.com");
-
   }
 
   //StudentIdに基づく受講生情報検索②

--- a/src/test/java/raisetech/StudentManagement/repository/StudentRepositoryTest.java
+++ b/src/test/java/raisetech/StudentManagement/repository/StudentRepositoryTest.java
@@ -29,36 +29,6 @@ class StudentRepositoryTest {
     criteria = new StudentDetailSearchCriteria();
   }
 
-  //受講生情報一覧検索①
-  @Test
-  void キャンセル扱いを除いた受講生情報の全件を検索できること() {
-    List<Student> actual = sut.searchStudents();
-    assertThat(actual.size()).isEqualTo(4);
-  }
-
-  //受講生情報一覧検索②
-  @Test
-  void キャンセル扱いの受講生は検索結果に含まれないこと() {
-    List<Student> actual = sut.searchStudents();
-    boolean containsDeleted = actual.stream()
-        .anyMatch(student -> student.getStudentId() == 4);
-    assertThat(containsDeleted).isFalse();
-  }
-
-  //受講コース情報一覧検索
-  @Test
-  void 受講コース情報の全件を検索できること() {
-    List<StudentCourse> actual = sut.searchStudentsCourses();
-    assertThat(actual.size()).isEqualTo(6);
-  }
-
-  //受講コース情報一覧検索
-  @Test
-  void 全件取得でcourse_statusが全て取得できること() {
-    List<CourseStatus> actual = sut.searchCoursesStatus();
-    assertThat(actual.size()).isEqualTo(6);
-  }
-
   // 条件指定受講生検索1
   @Test
   void 条件指定検索_検索条件に氏名を指定して想定通り検索できること() {
@@ -252,8 +222,9 @@ class StudentRepositoryTest {
 
   @Test
   void コース申込状況を新規登録できること() {
+    Integer courseId = 7;
     LocalDate today = LocalDate.now();
-    CourseStatus courseStatus = TestDataFactory.createInitCourseStatus(null, 2);
+    CourseStatus courseStatus = TestDataFactory.createInitCourseStatus(null, courseId);
 
     sut.registerCourseStatus(courseStatus);
 
@@ -261,18 +232,16 @@ class StudentRepositoryTest {
     assertThat(courseStatus.getCourseStatusId()).isNotNull();
 
     // IDが割り当てられたことを前提に検索・内容を検証
-    CourseStatus actual = sut.searchCoursesStatus().stream()
-        .filter(cs -> cs.getCourseStatusId().equals(courseStatus.getCourseStatusId()))
-        .findFirst()
-        .orElseThrow();
-
-    assertThat(actual)
+    List<CourseStatus> actualList = sut.searchCourseStatusByCourseIdList(List.of(courseId));
+    assertThat(actualList)
+        .hasSize(1)
+        .first()
         .extracting(
             CourseStatus::getCourseId,
             CourseStatus::getStatus,
             CourseStatus::getProvisionalApplicationDate
         )
-        .containsExactly(2, "仮申込", today);
+        .containsExactly(courseId, "仮申込", today);
   }
 
   //受講生更新処理
@@ -323,10 +292,9 @@ class StudentRepositoryTest {
 
   @Test
   void 受講コース申込状況の更新が行えること() {
-    CourseStatus courseStatus = sut.searchCoursesStatus().stream()
-        .filter(cs -> cs.getCourseStatusId().equals(2))
-        .findFirst()
-        .orElseThrow();
+    List<CourseStatus> courseStatusList = sut.searchCourseStatusByCourseIdList(List.of(2));
+    assertThat(courseStatusList).hasSize(1);
+    CourseStatus courseStatus = courseStatusList.getFirst();
 
     courseStatus.setStatus("受講完了");
     courseStatus.setCancelDate(LocalDate.of(2025, 4, 15));
@@ -335,10 +303,9 @@ class StudentRepositoryTest {
     sut.updateCourseStatus(courseStatus);
 
     // 更新後のデータを再取得して検証
-    CourseStatus actual = sut.searchCoursesStatus().stream()
-        .filter(cs -> cs.getCourseStatusId().equals(2))
-        .findFirst()
-        .orElseThrow();
+    List<CourseStatus> updatedList = sut.searchCourseStatusByCourseIdList(List.of(2));
+    assertThat(updatedList).hasSize(1);
+    CourseStatus actual = updatedList.getFirst();
 
     assertThat(actual)
         .extracting(

--- a/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
@@ -194,25 +194,6 @@ class StudentServiceTest {
   }
 
   @Test
-  void 受講生詳細情報の一覧検索_repositoryとconverterの処理が適切に呼び出せていること() {
-    when(repository.searchStudents()).thenReturn(List.of(student));
-    when(repository.searchStudentsCourses()).thenReturn(studentCourseList);
-    when(repository.searchCoursesStatus()).thenReturn(courseStatusList);
-    when(converter.convertCourseDetailList(studentCourseList, courseStatusList)).thenReturn(
-        courseDetailList);
-    when(converter.convertStudentDetailList(List.of(student), courseDetailList)).thenReturn(
-        List.of(studentDetail));
-
-    List<StudentDetail> actual = sut.getStudentDetailList();
-
-    verify(repository, times(1)).searchStudents();
-    verify(repository, times(1)).searchStudentsCourses();
-    verify(repository, times(1)).searchCoursesStatus();
-    verify(converter, times(1)).convertCourseDetailList(studentCourseList, courseStatusList);
-    verify(converter, times(1)).convertStudentDetailList(List.of(student), courseDetailList);
-  }
-
-  @Test
   void 個人の受講生詳細情報の検索_StudentとCourseDetailがあるの場合_repositoryとconverterが適切に呼出され且つStudentDetailが適切に生成されていること() {
     when(repository.searchStudentByStudentId(studentId)).thenReturn(student);
     when(repository.searchStudentCoursesByStudentId(studentId)).thenReturn(studentCourseList);

--- a/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -32,6 +34,7 @@ import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
 import raisetech.StudentManagement.domain.CourseDetail;
 import raisetech.StudentManagement.domain.StudentDetail;
+import raisetech.StudentManagement.domain.criteria.StudentDetailSearchCriteria;
 import raisetech.StudentManagement.repository.StudentRepository;
 import raisetech.StudentManagement.service.converter.StudentConverter;
 
@@ -98,6 +101,96 @@ class StudentServiceTest {
   // テストデータを提供するメソッド
   static Stream<List<StudentCourse>> provideStudentCourseLists() {
     return Stream.of(null, Collections.emptyList());
+  }
+
+  //受講生条件検索1
+  @Test
+  void 検索条件に該当する受講生詳細情報の一覧が正しく取得できること() {
+    StudentDetailSearchCriteria criteria = new StudentDetailSearchCriteria();
+
+    when(repository.searchStudentsByCriteria(criteria)).thenReturn(List.of(student));
+    when(repository.searchStudentsCoursesByCriteria(criteria)).thenReturn(studentCourseList);
+    when(repository.searchCourseStatusesByCriteria(criteria)).thenReturn(courseStatusList);
+    when(converter.combineStudentCourseWithCourseStatusByCourseId(studentCourseList,
+        courseStatusList))
+        .thenReturn(courseDetailList);
+    when(converter.combineStudentsWithCourseDetailsByStudentId(List.of(student), courseDetailList))
+        .thenReturn(List.of(studentDetail));
+
+    List<StudentDetail> actual = sut.searchStudentDetailListByCriteria(criteria);
+
+    assertEquals(1, actual.size());
+    assertEquals(studentDetail, actual.getFirst());
+
+    verify(repository, times(1)).searchStudentsByCriteria(criteria);
+    verify(repository, times(1)).searchStudentsCoursesByCriteria(criteria);
+    verify(repository, times(1)).searchCourseStatusesByCriteria(criteria);
+    verify(converter, times(1)).combineStudentCourseWithCourseStatusByCourseId(
+        studentCourseList, courseStatusList);
+    verify(converter, times(1)).combineStudentsWithCourseDetailsByStudentId(List.of(student),
+        courseDetailList);
+  }
+
+  //受講生条件検索2
+  @ParameterizedTest
+  @MethodSource("provideEachLists")
+  void 検索結果が空のテーブルがあった場合にrepositoryは実行されconverterは実行されずに空リストが返ること(
+      List<Student> studentList,
+      List<StudentCourse> studentCourseList,
+      List<CourseStatus> courseStatusList) {
+    StudentDetailSearchCriteria criteria = new StudentDetailSearchCriteria();
+
+    when(repository.searchStudentsByCriteria(criteria)).thenReturn(studentList);
+    when(repository.searchStudentsCoursesByCriteria(criteria)).thenReturn(studentCourseList);
+    when(repository.searchCourseStatusesByCriteria(criteria)).thenReturn(courseStatusList);
+
+    List<StudentDetail> actual = sut.searchStudentDetailListByCriteria(criteria);
+
+    assertEquals(Collections.emptyList(), actual);
+
+    verify(repository, times(1)).searchStudentsByCriteria(criteria);
+    verify(repository, times(1)).searchStudentsCoursesByCriteria(criteria);
+    verify(repository, times(1)).searchCourseStatusesByCriteria(criteria);
+    verify(converter, never()).combineStudentCourseWithCourseStatusByCourseId(anyList(), anyList());
+    verify(converter, never()).combineStudentsWithCourseDetailsByStudentId(anyList(), anyList());
+  }
+
+  // 受講生条件検索2 テストケース
+  static Stream<Arguments> provideEachLists() {
+    Student student = createStudentNormalSimple(999);
+    StudentCourse studentCourse = createStudentCourseNormalSimple(999, 999);
+    CourseStatus courseStatus = createInitCourseStatus(999, 999);
+    return Stream.of(
+        Arguments.of(Collections.emptyList(), List.of(studentCourse), List.of(courseStatus)),
+        Arguments.of(List.of(student), Collections.emptyList(), List.of(courseStatus)),
+        Arguments.of(List.of(student), List.of(studentCourse), Collections.emptyList())
+    );
+  }
+
+  //受講生条件検索3
+  @Test
+  void 該当する検索条件を満たすCourseDetailがない場合に全てのrepositoryと適切なconverterのみ実行され空リストが返ること() {
+    StudentDetailSearchCriteria criteria = new StudentDetailSearchCriteria();
+    List<StudentCourse> studentCourseList = List.of(course1);
+    List<CourseStatus> courseStatusList = List.of(initStatus2);
+
+    when(repository.searchStudentsByCriteria(criteria)).thenReturn(List.of(student));
+    when(repository.searchStudentsCoursesByCriteria(criteria)).thenReturn(studentCourseList);
+    when(repository.searchCourseStatusesByCriteria(criteria)).thenReturn(courseStatusList);
+    when(converter.combineStudentCourseWithCourseStatusByCourseId(studentCourseList,
+        courseStatusList))
+        .thenReturn(Collections.emptyList());
+
+    List<StudentDetail> actual = sut.searchStudentDetailListByCriteria(criteria);
+
+    assertEquals(Collections.emptyList(), actual);
+
+    verify(repository, times(1)).searchStudentsByCriteria(criteria);
+    verify(repository, times(1)).searchStudentsCoursesByCriteria(criteria);
+    verify(repository, times(1)).searchCourseStatusesByCriteria(criteria);
+    verify(converter, times(1)).combineStudentCourseWithCourseStatusByCourseId(studentCourseList,
+        courseStatusList);
+    verify(converter, never()).combineStudentsWithCourseDetailsByStudentId(anyList(), anyList());
   }
 
   @Test
@@ -294,4 +387,6 @@ class StudentServiceTest {
     assertNotNull(actual);
     assertTrue(actual.isEmpty());
   }
+
+
 }

--- a/src/test/java/raisetech/StudentManagement/service/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/converter/StudentConverterTest.java
@@ -1,5 +1,6 @@
 package raisetech.StudentManagement.service.converter;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static raisetech.StudentManagement.testutil.TestDataFactory.createInitCourseStatus;
 import static raisetech.StudentManagement.testutil.TestDataFactory.createStudentCourseNormalSimple;
 import static raisetech.StudentManagement.testutil.TestDataFactory.createStudentNormalSimple;
@@ -21,13 +22,17 @@ import raisetech.StudentManagement.domain.StudentDetail;
 
 class StudentConverterTest {
 
+  private StudentConverter sut;
   private Student student1, student2, student3;
   private StudentCourse course1, course2, course3;
   private CourseStatus status1, status2, status3;
   private CourseDetail courseDetail1, courseDetail2, courseDetail3;
+  private StudentDetail studentDetail1, studentDetail2, studentDetail3;
 
   @BeforeEach
   void setUp() {
+    sut = new StudentConverter();
+
     student1 = createStudentNormalSimple(999);
     student2 = createStudentNormalSimple(1000);
     student3 = createStudentNormalSimple(1001);
@@ -43,6 +48,11 @@ class StudentConverterTest {
     courseDetail1 = new CourseDetail(course1, status1);
     courseDetail2 = new CourseDetail(course2, status2);
     courseDetail3 = new CourseDetail(course3, status3);
+
+    studentDetail1 = new StudentDetail(student1, List.of(courseDetail1, courseDetail2));
+    studentDetail2 = new StudentDetail(student2, List.of(courseDetail3));
+    studentDetail3 = new StudentDetail(student3, List.of());
+
   }
 
   @Test
@@ -52,15 +62,10 @@ class StudentConverterTest {
     List<CourseDetail> courseDetails = List.of(courseDetail1, courseDetail2, courseDetail3);
 
     // Act（対象メソッドの呼び出し）
-    StudentConverter sut = new StudentConverter();
     List<StudentDetail> actual = sut.convertStudentDetailList(students, courseDetails);
 
     // 期待されるオブジェクトを生成
-    StudentDetail expectedDetail1 = new StudentDetail(student1,
-        List.of(courseDetail1, courseDetail2));
-    StudentDetail expectedDetail2 = new StudentDetail(student2, List.of(courseDetail3));
-    StudentDetail expectedDetail3 = new StudentDetail(student3, List.of());
-    List<StudentDetail> expected = List.of(expectedDetail1, expectedDetail2, expectedDetail3);
+    List<StudentDetail> expected = List.of(studentDetail1, studentDetail2, studentDetail3);
     // JSON比較
     ObjectMapper mapper = new ObjectMapper();
     mapper.registerModule(new JavaTimeModule());
@@ -79,15 +84,10 @@ class StudentConverterTest {
     List<CourseStatus> courseStatuses = List.of(status1, status2, status3);
 
     // Act
-    StudentConverter sut = new StudentConverter();
     List<CourseDetail> actual = sut.convertCourseDetailList(studentCourses, courseStatuses);
 
     // Assert - 期待される結果を準備
-    List<CourseDetail> expected = List.of(
-        new CourseDetail(course1, status1),
-        new CourseDetail(course2, status2),
-        new CourseDetail(course3, status3)
-    );
+    List<CourseDetail> expected = List.of(courseDetail1, courseDetail2, courseDetail3);
 
     // JSON比較
     ObjectMapper mapper = new ObjectMapper();
@@ -99,4 +99,72 @@ class StudentConverterTest {
 
     JSONAssert.assertEquals(expectedJson, actualJson, true);
   }
+
+  @Test
+  void studentCourseとCourseStatusで共通のcourseIdを持つ組みのみからなるCourseDetailのリストに変換されること()
+      throws JsonProcessingException, JSONException {
+    List<StudentCourse> studentCourseList = List.of(course1, course3);
+    List<CourseStatus> courseStatusList = List.of(status1, status2);
+
+    List<CourseDetail> actual = sut.combineStudentCourseWithCourseStatusByCourseId(
+        studentCourseList,
+        courseStatusList);
+
+    // 期待されるオブジェクトを生成
+    List<CourseDetail> expected = List.of(courseDetail1);
+
+    // JSON比較
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+    mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    String actualJson = mapper.writeValueAsString(actual);
+    String expectedJson = mapper.writeValueAsString(expected);
+
+    JSONAssert.assertEquals(expectedJson, actualJson, true);
+  }
+
+  @Test
+  void studentCourseとCourseStatusで共通のcourseIdを持つ組み合わせがない場合空リストが返ること() {
+    List<StudentCourse> studentCourses = List.of(course1, course2);
+    List<CourseStatus> courseStatuses = List.of(status3);
+
+    List<CourseDetail> actual = sut.combineStudentCourseWithCourseStatusByCourseId(studentCourses,
+        courseStatuses);
+
+    assertTrue(actual.isEmpty());
+  }
+
+  @Test
+  void studentとCourseDetaiで共通のstudentIdを持つ組みのみからなるStudentDetailのリストに変換されること()
+      throws JsonProcessingException, JSONException {
+    List<Student> studentList = List.of(student1, student3);
+    List<CourseDetail> courseDetailList = List.of(courseDetail1, courseDetail2, courseDetail3);
+
+    List<StudentDetail> actual = sut.combineStudentsWithCourseDetailsByStudentId(studentList,
+        courseDetailList);
+
+    List<StudentDetail> expected = List.of(studentDetail1);
+
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+    mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    String actualJson = mapper.writeValueAsString(actual);
+    String expectedJson = mapper.writeValueAsString(expected);
+
+    JSONAssert.assertEquals(expectedJson, actualJson, true);
+  }
+
+  @Test
+  void studentとCourseDetailで共通のstudentIdを持つ組み合わせがない場合空リストが返ること() {
+    List<Student> studentList = List.of(student1, student3);
+    List<CourseDetail> courseDetailList = List.of(courseDetail3);
+
+    List<StudentDetail> actual = sut.combineStudentsWithCourseDetailsByStudentId(studentList,
+        courseDetailList);
+
+    assertTrue(actual.isEmpty());
+  }
+
 }

--- a/src/test/java/raisetech/StudentManagement/service/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/converter/StudentConverterTest.java
@@ -27,7 +27,7 @@ class StudentConverterTest {
   private StudentCourse course1, course2, course3;
   private CourseStatus status1, status2, status3;
   private CourseDetail courseDetail1, courseDetail2, courseDetail3;
-  private StudentDetail studentDetail1, studentDetail2, studentDetail3;
+  private StudentDetail studentDetail1;
 
   @BeforeEach
   void setUp() {
@@ -50,31 +50,6 @@ class StudentConverterTest {
     courseDetail3 = new CourseDetail(course3, status3);
 
     studentDetail1 = new StudentDetail(student1, List.of(courseDetail1, courseDetail2));
-    studentDetail2 = new StudentDetail(student2, List.of(courseDetail3));
-    studentDetail3 = new StudentDetail(student3, List.of());
-
-  }
-
-  @Test
-  void studentとCourseDetailの情報からJSON形式のstudentDetailに期待通りに変換されること()
-      throws JsonProcessingException, JSONException {
-    List<Student> students = List.of(student1, student2, student3);
-    List<CourseDetail> courseDetails = List.of(courseDetail1, courseDetail2, courseDetail3);
-
-    // Act（対象メソッドの呼び出し）
-    List<StudentDetail> actual = sut.convertStudentDetailList(students, courseDetails);
-
-    // 期待されるオブジェクトを生成
-    List<StudentDetail> expected = List.of(studentDetail1, studentDetail2, studentDetail3);
-    // JSON比較
-    ObjectMapper mapper = new ObjectMapper();
-    mapper.registerModule(new JavaTimeModule());
-    mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
-    String actualJson = mapper.writeValueAsString(actual);
-    String expectedJson = mapper.writeValueAsString(expected);
-
-    JSONAssert.assertEquals(expectedJson, actualJson, true);
   }
 
   @Test


### PR DESCRIPTION
3ef46a659ba0463a5e385e9551b00f363cbe0e0b
検索条件をまとめたclassを作成し、ここで定義される検索項目が検索できるようにしました。
追加
＜domain＞に＜criteria.StudentDetailSearchCriteria＞の条件項目classを作成
＜controller＞条件指定での検索処理を追加
＜service＞条件指定での検索機能を追加
　　→DBの各テーブルで関連する検索項目の指定条件のみの一覧を取得し突合せで検索結果の一覧を作成する処理を追加
＜repository＞＜repository.xml＞
　　→DBの各テーブルで関連する検索項目の指定条件のみの一覧を取得する処理を追加
＜converter＞
　　→検索結果からStudentCourseとCourseStatusを突合せ両データが存在するCourseDetailのリストを作成する処理を追加
　　　※上記でStudentCourseとCourseStatusに関連する条件を満たすCourseDetailが得られる。
　　→作成したCourseDetailと検索したStudnetを突合せ両データが存在するStudentDetailのリストを作成する処理を追加
　　　※上記で全条件を満たすStudentDetailが得られる。

上記の追加に伴う各種テストを追加
repositoryのテストで追加機能のテストをしやすくするためにH2用のdataも修正

追加機能の実行結果
名前の部分一致のみ設定(受講生2件分）
![image](https://github.com/user-attachments/assets/0d3ba716-da23-42da-80be-d5d156169f09)
![image](https://github.com/user-attachments/assets/fd812f1c-59d3-4b62-92eb-2532150a2623)

名前部分一致＋コース（上の結果から二人目の2つ目のコース情報が除かれている。)
![image](https://github.com/user-attachments/assets/28787e55-6934-491f-9dfb-7e5d4f7f2071)
![image](https://github.com/user-attachments/assets/65a7b782-b88c-4094-9a45-f0f6995ddf69)
![image](https://github.com/user-attachments/assets/2f237818-fa28-4b69-8ee6-eacf9a36f76d)

名前部分一致＋コース ＋申込状況（上の結果から一人目の受講生の情報が除かれている。）
![image](https://github.com/user-attachments/assets/a0564e74-6aa9-48e3-8c9a-6808096963c6)
![image](https://github.com/user-attachments/assets/9ebcbd6b-1015-4bfd-8c25-8ed58bc4fe51)


controllerテスト結果
![image](https://github.com/user-attachments/assets/0fca3fdb-d6c7-4357-adf8-d6f7cd24c040)

validationテストの結果
![image](https://github.com/user-attachments/assets/9eed636d-aae2-4f1c-a97e-059d528d8697)

serviceテスト結果
![image](https://github.com/user-attachments/assets/68607201-f884-4678-a49c-5f7943b81c21)

repositoryテスト結果
![image](https://github.com/user-attachments/assets/9bbb22fe-0060-4e59-83ca-04383400b76f)

converterテスト結果
![image](https://github.com/user-attachments/assets/0709af8f-9544-4fd7-9708-4a644deef4ea)