### PR TITLE
ControllerとServiceへの処理内容の移管/受講生および受講コースの抽出処理の実装

### DIFF
--- a/src/main/java/raisetech/StudentManagement/StudentManagementApplication.java
+++ b/src/main/java/raisetech/StudentManagement/StudentManagementApplication.java
@@ -1,38 +1,13 @@
 package raisetech.StudentManagement;
 
-import java.util.List;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 
 @SpringBootApplication
-@RestController
 public class StudentManagementApplication {
-
-  @Autowired
-  public StudentRepository repository;
 
   public static void main(String[] args) {
     SpringApplication.run(StudentManagementApplication.class, args);
-  }
-
-  @GetMapping("/studentList")
-  public List<Student> getStudentList() {
-    return repository.searchStudentList();
-  }
-
-  //todo:引数をpublicIdに変更する
-  @GetMapping("/student")
-  public Student getStudentById(@RequestParam Integer studentId) {
-    return repository.searchStudentById(studentId);
-  }
-
-  @GetMapping("/studentCourseList")
-  public List<StudentCourse> getStudentCourseList() {
-    return repository.searchStudentCourseList();
   }
 
 }

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -1,0 +1,38 @@
+package raisetech.StudentManagement.controller;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import raisetech.StudentManagement.date.Student;
+import raisetech.StudentManagement.date.StudentCourse;
+import raisetech.StudentManagement.service.StudentService;
+
+@RestController
+public class StudentController {
+
+  public StudentService service;
+
+  @Autowired
+  public StudentController(StudentService service) {
+    this.service = service;
+  }
+
+  @GetMapping("/studentList")
+  public List<Student> getStudentList() {
+    return service.searchStudentList();
+  }
+
+  //todo:引数をpublicIdに変更する
+  @GetMapping("/student")
+  public Student getStudentById(@RequestParam Integer studentId) {
+    return service.searchStudentById(studentId);
+  }
+
+  @GetMapping("/studentCourseList")
+  public List<StudentCourse> getStudentCourseList() {
+    return service.searchStudentCourseList();
+  }
+
+}

--- a/src/main/java/raisetech/StudentManagement/date/Student.java
+++ b/src/main/java/raisetech/StudentManagement/date/Student.java
@@ -1,4 +1,4 @@
-package raisetech.StudentManagement;
+package raisetech.StudentManagement.date;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/raisetech/StudentManagement/date/StudentCourse.java
+++ b/src/main/java/raisetech/StudentManagement/date/StudentCourse.java
@@ -1,4 +1,4 @@
-package raisetech.StudentManagement;
+package raisetech.StudentManagement.date;
 
 import java.time.LocalDate;
 import lombok.Getter;

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -1,8 +1,10 @@
-package raisetech.StudentManagement;
+package raisetech.StudentManagement.repository;
 
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
+import raisetech.StudentManagement.date.Student;
+import raisetech.StudentManagement.date.StudentCourse;
 
 @Mapper
 public interface StudentRepository {

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -18,7 +18,10 @@ public class StudentService {
   }
 
   public List<Student> searchStudentList() {
-    return repository.searchStudentList();
+    List<Student> studentList = repository.searchStudentList();
+    return studentList.stream()
+        .filter(student -> student.getAge() >= 30 && student.getAge() < 40)
+        .toList();
   }
 
   //todo:引数をpublicIdに変更する
@@ -27,7 +30,10 @@ public class StudentService {
   }
 
   public List<StudentCourse> searchStudentCourseList() {
-    return repository.searchStudentCourseList();
+    List<StudentCourse> courseList = repository.searchStudentCourseList();
+    return courseList.stream()
+        .filter(course -> course.getCourse().equals("Java"))
+        .toList();
   }
 
 

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -1,0 +1,34 @@
+package raisetech.StudentManagement.service;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import raisetech.StudentManagement.date.Student;
+import raisetech.StudentManagement.date.StudentCourse;
+import raisetech.StudentManagement.repository.StudentRepository;
+
+@Service
+public class StudentService {
+
+  private StudentRepository repository;
+
+  @Autowired
+  public StudentService(StudentRepository repository) {
+    this.repository = repository;
+  }
+
+  public List<Student> searchStudentList() {
+    return repository.searchStudentList();
+  }
+
+  //todo:引数をpublicIdに変更する
+  public Student searchStudentById(Integer studentId) {
+    return repository.searchStudentById(studentId);
+  }
+
+  public List<StudentCourse> searchStudentCourseList() {
+    return repository.searchStudentCourseList();
+  }
+
+
+}


### PR DESCRIPTION
24_Read処理のServiceとController部分を実装
## 変更及び実装内容
**概要**
・ファイル構成の整理とMainの処理の移管　[bfc158e95cfe4d960403fa05f5ed3f2edc0bf244]
・Service：検索結果から所定条件を満たすのレコードのみを抽出する処理の実装　[53443e5a9c4f357254751adf620fb882afb3b25a]

**詳細**
bfc158e95cfe4d960403fa05f5ed3f2edc0bf244 ：MainからControllerとServiceへの処理移管と各ファイル構成整理
　・ControllerとServiceクラスの作成
　　　→Mainの実装メソッドを上記各クラスに移管
　・各クラスをパッケージで役割ごとに整理

53443e5a9c4f357254751adf620fb882afb3b25a ：受講生の抽出処理(30代のみ)と受講コースの抽出処理(Javaのみ)の実装
　課題
　＜Service＞
　　　受講生の全件検索から「30代」のみのリストに直しControllerに返す処理の実装
　　　受講コースの全件検索からコース名「Java」のみのリストに直しControllerに返す処理の実装

## 実行結果
![image](https://github.com/user-attachments/assets/287b8192-0fc2-4ef9-b22c-8076323e18b4)

MySQL
![image](https://github.com/user-attachments/assets/01936a0f-ff7b-487b-b676-019d0ee8bd96)




