### PR TITLE
Studentの項目追加/StudentDetailの全件取得の実装

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -5,34 +5,35 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import raisetech.StudentManagement.controller.converter.StudentConverter;
 import raisetech.StudentManagement.date.Student;
 import raisetech.StudentManagement.date.StudentCourse;
+import raisetech.StudentManagement.domain.StudentDetail;
 import raisetech.StudentManagement.service.StudentService;
 
 @RestController
 public class StudentController {
 
-  public StudentService service;
+  private StudentService service;
+  private StudentConverter converter;
 
   @Autowired
-  public StudentController(StudentService service) {
+  public StudentController(StudentService service, StudentConverter converter) {
     this.service = service;
+    this.converter = converter;
   }
 
   @GetMapping("/studentList")
-  public List<Student> getStudentList() {
-    return service.searchStudentList();
+  public List<StudentDetail> getStudentList() {
+    List<Student> studentList = service.searchStudentList();
+    List<StudentCourse> studentCourseList = service.searchStudentCourseList();
+    return converter.convertToStudentDetail(studentList, studentCourseList);
   }
 
   //todo:引数をpublicIdに変更する
   @GetMapping("/student")
   public Student getStudentById(@RequestParam Integer studentId) {
     return service.searchStudentById(studentId);
-  }
-
-  @GetMapping("/studentCourseList")
-  public List<StudentCourse> getStudentCourseList() {
-    return service.searchStudentCourseList();
   }
 
 }

--- a/src/main/java/raisetech/StudentManagement/controller/converter/StudentConverter.java
+++ b/src/main/java/raisetech/StudentManagement/controller/converter/StudentConverter.java
@@ -1,0 +1,24 @@
+package raisetech.StudentManagement.controller.converter;
+
+import java.util.List;
+import org.springframework.stereotype.Component;
+import raisetech.StudentManagement.date.Student;
+import raisetech.StudentManagement.date.StudentCourse;
+import raisetech.StudentManagement.domain.StudentDetail;
+
+@Component
+public class StudentConverter {
+
+  public List<StudentDetail> convertToStudentDetail(List<Student> studentList,
+      List<StudentCourse> studentCourseList) {
+
+    return studentList.stream()
+        .map(student -> new StudentDetail(student,
+            studentCourseList.stream()
+                .filter(
+                    studentCourse -> studentCourse.getStudentId().equals(student.getStudentId()))
+                .toList()))
+        .toList();
+  }
+
+}

--- a/src/main/java/raisetech/StudentManagement/date/Student.java
+++ b/src/main/java/raisetech/StudentManagement/date/Student.java
@@ -21,5 +21,7 @@ public class Student {
   private String region;
   private Integer age;
   private String sex;
+  private String remark;
+  private boolean isDeleted;
 
 }

--- a/src/main/java/raisetech/StudentManagement/domain/StudentDetail.java
+++ b/src/main/java/raisetech/StudentManagement/domain/StudentDetail.java
@@ -1,0 +1,18 @@
+package raisetech.StudentManagement.domain;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import raisetech.StudentManagement.date.Student;
+import raisetech.StudentManagement.date.StudentCourse;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class StudentDetail {
+
+  private Student student;
+  private List<StudentCourse> studentCourseList;
+
+}

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -18,22 +18,16 @@ public class StudentService {
   }
 
   public List<Student> searchStudentList() {
-    List<Student> studentList = repository.searchStudentList();
-    return studentList.stream()
-        .filter(student -> student.getAge() >= 30 && student.getAge() < 40)
-        .toList();
+    return repository.searchStudentList();
+  }
+
+  public List<StudentCourse> searchStudentCourseList() {
+    return repository.searchStudentCourseList();
   }
 
   //todo:引数をpublicIdに変更する
   public Student searchStudentById(Integer studentId) {
     return repository.searchStudentById(studentId);
-  }
-
-  public List<StudentCourse> searchStudentCourseList() {
-    List<StudentCourse> courseList = repository.searchStudentCourseList();
-    return courseList.stream()
-        .filter(course -> course.getCourse().equals("Java"))
-        .toList();
   }
 
 


### PR DESCRIPTION
25_Read処理のConverter部分実装

## 実装・変更内容
**bc88485b45d0ca80a9a19da813b8d10a599a2d9f ：Studentの項目追加とServiceのフィルタリング機能の削除**
・Studentの項目追加
・Serviceの前回課題の削除(Student全件＆StudentCourse全件取得に戻す）

**9291755f40eb808c4d53f5caad023fccc9f00a51 ：StudentDetaiの作成とControllerでの表示内容の変更**
・StudentDetailの作成
・StudentConverterの作成：List＜Student＞とList＜StudentCourse＞ →List＜StudentDetail＞に変換
・Controllerの修正：Student一覧とStudentCourse一覧の表示処理をStudentDetail一覧の表示処理にまとめる。

## 実行結果
**GitBush**(ベースのスクショは共通）
studentId=1 : Student +[StudentCourse 2件]
![image](https://github.com/user-attachments/assets/649fde8d-4066-45db-9e16-086953cf56cd)

studentId=2 : Student +[StudentCourse 1件]
![image](https://github.com/user-attachments/assets/4ef29908-1c39-4e16-97a9-b8051e59e414)

studentId=5 : Student +[StudentCourse 0件]
![image](https://github.com/user-attachments/assets/18880472-01da-49f8-b5db-fc689ce043e7)

**MySQL**
・studentにremarkとis_deletedを追加
・各studentIdに紐づくコース情報について上記の出力との整合性確認
![image](https://github.com/user-attachments/assets/711a0612-0edf-457b-8015-42640524eff2)

