### PR TITLE
Thymeleafでの画面描画処理の実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,10 @@ repositories {
 }
 
 dependencies {
+    //Spring Boot
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    //Thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     //Apache Commons Lang
     implementation 'org.apache.commons:commons-lang3:3.17.0'
     //SQLドライバ

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -2,16 +2,17 @@ package raisetech.StudentManagement.controller;
 
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 import raisetech.StudentManagement.controller.converter.StudentConverter;
 import raisetech.StudentManagement.date.Student;
 import raisetech.StudentManagement.date.StudentCourse;
 import raisetech.StudentManagement.domain.StudentDetail;
 import raisetech.StudentManagement.service.StudentService;
 
-@RestController
+@Controller
 public class StudentController {
 
   private StudentService service;
@@ -24,10 +25,13 @@ public class StudentController {
   }
 
   @GetMapping("/studentList")
-  public List<StudentDetail> getStudentList() {
+  public String getStudentList(Model model) {
     List<Student> studentList = service.searchStudentList();
     List<StudentCourse> studentCourseList = service.searchStudentCourseList();
-    return converter.convertToStudentDetail(studentList, studentCourseList);
+    List<StudentDetail> studentDetailList = converter.convertToStudentDetail(studentList,
+        studentCourseList);
+    model.addAttribute("studentList", studentDetailList);
+    return "studentList";
   }
 
   //todo:引数をpublicIdに変更する

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1,0 +1,18 @@
+.studentTable {
+  border-collapse: collapse;
+  width: 95%;
+  margin: 0 auto;
+  font-size: 15px
+}
+
+.studentTable th,
+.studentTable td {
+  border: 1px solid #ccc;
+  padding: 5px;
+  text-align: left;
+}
+
+.studentTable thead {
+  background-color: #191970;
+  color: white;
+}

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>受講生情報一覧</title>
+  <link th:href="@{/css/style.css}" rel="stylesheet"/>
+</head>
+
+<body>
+<h2>受講生情報</h2>
+<table class="studentTable">
+  <colgroup>
+    <col style="width: 8%;">
+    <col style="width: 10%;">
+    <col style="width: 15%;">
+    <col style="width: 12%;">
+    <col style="width: 23%;">
+    <col style="width: 12%;">
+    <col style="width: 5%;">
+    <col style="width: 5%;">
+    <col style="width: 10%;">
+  </colgroup>
+  <thead>
+  <tr>
+    <th>ID</th>
+    <th>名前</th>
+    <th>カナ</th>
+    <th>ニックネーム</th>
+    <th>メールアドレス</th>
+    <th>地域</th>
+    <th>年齢</th>
+    <th>性別</th>
+    <th>備考</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr th:each="studentDetail : ${studentList}">
+    <td th:text="${#strings.substring(studentDetail.student.publicId, 0, 8)}"
+        th:title="${studentDetail.student.publicId}">a1b2c3d4
+    </td>
+    <td th:text="${studentDetail.student.fullName}">山田 太郎</td>
+    <td th:text="${studentDetail.student.kanaName}">ヤマダ タロウ</td>
+    <td th:text="${studentDetail.student.nickname}">たろちゃん</td>
+    <td th:text="${studentDetail.student.email}">taro@example.com</td>
+    <td th:text="${studentDetail.student.region}">東京都 千代田区</td>
+    <td th:text="${studentDetail.student.age}">25</td>
+    <td th:text="${studentDetail.student.sex}">男性</td>
+    <td th:text="${studentDetail.student.remark}">特になし</td>
+  </tr>
+  </tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
**27_Thymeleafを使ったReadの画面描画処理**
## 実装内容
**879d7ffc66d39bbaf0cf6fafaf50217dfdf3c658 ：Thymeleafでの画面描画処理の実装**
・Thymeleafに関する依存関係の追加
・studentList.htmlの作成：List＜StudentDetail＞を受け渡し、Studentの一覧(テーブル)を表示
・Controller：画面描画処理を実行できる形式に書き換え
・style.cssの作成（studentList.htmlのテーブルの意匠情報管理）

補足：studentIdは内部処理用のIdとして持たせているため外部表示項目には設定しませんでした。
　　　外部表示用IDにpublicIdを設けており開示していますが、UUIDで長いため表示の仕様を下記のようにしています。
　　　　・始めの8文字をテーブルに表示
　　　　・ツールチップでマウスでホバーしたときに全部表示。

## 実行結果
画面内容
![image](https://github.com/user-attachments/assets/45ad93db-4aca-4503-8417-eda4afda29a9)　　

publicIdの全表示時
<img width="949" alt="image" src="https://github.com/user-attachments/assets/3de0666a-c67b-4b52-8908-724eba8d0656" />
