### PR TITLE
全件検索の変更：論理削除項目の除外とそれに伴う画面のルート変更

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -56,6 +56,9 @@ public class StudentController {
   public String updateStudent(@ModelAttribute StudentDetail studentDetail,
       RedirectAttributes redirectAttributes) {
     service.updateStudentDetail(studentDetail);
+    if (studentDetail.getStudent().isDeleted()) {
+      return "redirect:/studentList";
+    }
     redirectAttributes.addAttribute("publicId", studentDetail.getStudent().getPublicId());
     return "redirect:/student/{publicId}";
   }

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -12,7 +12,7 @@ import raisetech.StudentManagement.date.StudentCourse;
 @Mapper
 public interface StudentRepository {
 
-  @Select("SELECT * FROM students")
+  @Select("SELECT * FROM students WHERE is_deleted = false")
   List<Student> searchStudentList();
 
   @Select("SELECT * FROM students_courses")


### PR DESCRIPTION
30_受講生情報更新処理の実装
31_受講生情報削除処理の実装

## 実装内容
論理削除実施項目の受講生一覧表示内容からの除外
　repository：受講生の検索対象をキャンセルされてない項目に限定
更新時に削除した場合の画面遷移ルートの変更
　変更前：更新画面→受講生単独画面　(更新内容によらずすべて）
　変更後：更新画面→受講生一覧画面　(キャンセルにチェックを入れた場合のみ、それ以外の場合は変更前と同様）

## 実行結果
受講生一覧(枠内のデータを論理削する)
<img width="932" alt="image" src="https://github.com/user-attachments/assets/5065e501-57c8-42dc-8c73-23299fa38c91" />

更新画面でキャンセルにチェックを入れる。
<img width="319" alt="image" src="https://github.com/user-attachments/assets/94c3bb33-9fca-4e1a-8cf4-65ce02b1953b" />

受講生一覧に遷移＆対象受講生情報は非表示
<img width="932" alt="image" src="https://github.com/user-attachments/assets/dc0b1778-9f51-4904-8a09-3bae35198567" />

MySQL students tableの更新後の内容
<img width="347" alt="image" src="https://github.com/user-attachments/assets/77637d5d-7117-4935-aca1-03eaf2e40c06" />

