### PR TITLE
CRUD処理のREST化

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -3,9 +3,7 @@ package raisetech.StudentManagement.controller;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -48,10 +46,9 @@ public class StudentController {
   }
 
   @PostMapping("/registerStudent")
-  public String registerStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
-    //Todo:バリデーションerror時の動作を入れる（バリデーション確認の機能実装後対応）
-    service.registerStudentDetail(studentDetail);
-    return "redirect:/studentList";
+  public ResponseEntity<StudentDetail> registerStudent(@RequestBody StudentDetail studentDetail) {
+    StudentDetail registerStudentDetail = service.registerStudentDetail(studentDetail);
+    return ResponseEntity.ok(registerStudentDetail);
   }
 
 }

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -2,21 +2,22 @@ package raisetech.StudentManagement.controller;
 
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 import raisetech.StudentManagement.controller.converter.StudentConverter;
 import raisetech.StudentManagement.date.Student;
 import raisetech.StudentManagement.date.StudentCourse;
 import raisetech.StudentManagement.domain.StudentDetail;
 import raisetech.StudentManagement.service.StudentService;
 
-@Controller
+@RestController
 public class StudentController {
 
   private StudentService service;
@@ -29,44 +30,21 @@ public class StudentController {
   }
 
   @GetMapping("/studentList")
-  public String getStudentList(Model model) {
+  public List<StudentDetail> getStudentList() {
     List<Student> studentList = service.searchStudentList();
     List<StudentCourse> studentCourseList = service.searchStudentCourseList();
-    List<StudentDetail> studentDetailList = converter.convertToStudentDetail(studentList,
-        studentCourseList);
-    model.addAttribute("studentList", studentDetailList);
-    return "studentList";
+    return converter.convertToStudentDetail(studentList, studentCourseList);
   }
 
   @GetMapping("/student/{publicId}")
-  public String getStudentByPublicId(@PathVariable String publicId, Model model) {
-    StudentDetail studentDetail = service.searchStudentDetailByPublicId(publicId);
-    model.addAttribute("studentDetail", studentDetail);
-    return "student";
+  public StudentDetail getStudentByPublicId(@PathVariable String publicId) {
+    return service.searchStudentDetailByPublicId(publicId);
   }
 
-  @GetMapping("/student/{publicId}/edit")
-  public String editStudent(@PathVariable String publicId, Model model) {
-    StudentDetail studentDetail = service.searchStudentDetailByPublicId(publicId);
-    model.addAttribute("studentDetail", studentDetail);
-    return "updateStudent";
-  }
-
-  @PostMapping("/updateStudent")
-  public String updateStudent(@ModelAttribute StudentDetail studentDetail,
-      RedirectAttributes redirectAttributes) {
+  @PutMapping("/updateStudent")
+  public ResponseEntity<String> updateStudent(@RequestBody StudentDetail studentDetail) {
     service.updateStudentDetail(studentDetail);
-    if (studentDetail.getStudent().isDeleted()) {
-      return "redirect:/studentList";
-    }
-    redirectAttributes.addAttribute("publicId", studentDetail.getStudent().getPublicId());
-    return "redirect:/student/{publicId}";
-  }
-
-  @GetMapping("/newStudent")
-  public String displayRegisterStudent(Model model) {
-    model.addAttribute("studentDetail", new StudentDetail());
-    return "registerStudent";
+    return ResponseEntity.ok("更新処理が完了しました");
   }
 
   @PostMapping("/registerStudent")

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -32,6 +32,7 @@ public interface StudentRepository {
 
   @Insert("INSERT INTO students_courses (student_id, course, start_date, end_date)"
       + "VALUES (#{studentId}, #{course}, #{startDate}, #{endDate})")
+  @Options(useGeneratedKeys = true, keyProperty = "courseId")
   void registerStudentCourse(StudentCourse studentcourse);
 
   @Update("UPDATE students "

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -37,7 +37,7 @@ public class StudentService {
   }
 
   @Transactional
-  public void registerStudentDetail(StudentDetail studentDetail) {
+  public StudentDetail registerStudentDetail(StudentDetail studentDetail) {
     //受講生の登録
     //Todo:emailの重複チェック（例外処理作成後に実装）
     UUID uuid = UUID.randomUUID();
@@ -50,6 +50,7 @@ public class StudentService {
         && !studentDetail.getStudentCourseList().isEmpty()) {
       registerStudentCourse(studentId, studentDetail.getStudentCourseList().getFirst());
     }
+    return studentDetail;
   }
 
   @Transactional


### PR DESCRIPTION
33_Read処理のRSET化とPostman実践

## 変更内容
f2d2a9fe2765a35ef5312953fa93224b983f3509 ：GET関連処理と更新処理のREST化
＜controller＞
　・受講生一覧・受講生単独検索機能のREST化
　・更新処理のREST化
　・不要メソッドの削除

42c80e5ebfc367996d674e6d617de9aca8f17f96 ：登録処理のREST化とそれに伴うservice,repositoryの修正
＜controller＞
　・登録処理のREST化
＜service・repository＞
　・登録結果を返す仕様に変更


## 実行結果
処理実行前のDB状態 (studentsにはcolumnにpublicIdがありますが一覧が見ずらいので表示項目に入れていません）
![image](https://github.com/user-attachments/assets/b497c105-3647-4332-ab60-b10659320723)

GET 受講生一覧検索　レスポンス
<img width="271" alt="image" src="https://github.com/user-attachments/assets/ed9040ce-f818-4d55-9f7f-90ce2e0526ff" />
<img width="225" alt="image" src="https://github.com/user-attachments/assets/174cd9ec-42cd-4e12-856f-776d4e8df6a5" />

受講生単独検索　レスポンス（IdはpublicIdで検索する仕様)
![image](https://github.com/user-attachments/assets/0cb8f926-7f2e-4eeb-9b9b-23ba2ae893dd)

更新処理　リクエストとレスポンス　(下線部が変更箇所)
<img width="302" alt="image" src="https://github.com/user-attachments/assets/cd826125-19c7-47f1-a6bc-3c2899191426" />

更新結果（受講生単独検索　レスポンス）
<img width="274" alt="image" src="https://github.com/user-attachments/assets/00ed8d51-5642-4c45-8343-61852336dac0" />

登録処理　リクエストとレスポンス　①～③
①受講生＆受講コース同時登録
![image](https://github.com/user-attachments/assets/bce18571-5f62-4cbb-85fa-789eb83ce10e)
![image](https://github.com/user-attachments/assets/5b0b9f6f-4753-4c06-897e-2e324ea886d8)

②受講生＆受講コース"空"（受講生のみ登録）
![image](https://github.com/user-attachments/assets/cef98645-2eba-4494-969a-1cde4eaad716)

③受講生＆受講コース"null" （受講生のみ登録）
![image](https://github.com/user-attachments/assets/10347df9-3da5-437b-ab79-77b3e8b2b179)

更新＆登録処理後DB
<img width="840" alt="image" src="https://github.com/user-attachments/assets/8374da23-7d80-420b-83cc-671b8bc4325c" />
