### PR TITLE
更新処理でのemail重複チェックの導入

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -84,7 +84,7 @@ public class StudentController {
   @PutMapping("/updateStudent")
   public ResponseEntity<String> updateStudent(
       @Validated(UpdateGroup.class)
-      @RequestBody StudentDetail studentDetail) {
+      @RequestBody StudentDetail studentDetail) throws NotUniqueException {
     service.updateStudentDetail(studentDetail);
     return ResponseEntity.ok("更新処理が完了しました");
   }

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -2,6 +2,7 @@ package raisetech.StudentManagement.repository;
 
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
 
@@ -76,4 +77,14 @@ public interface StudentRepository {
    * @return true 登録済みの場合、false 未登録の場合
    */
   boolean existsByEmail(String email);
+
+  /**
+   * 指定されたメールアドレスが既に登録されているかを確認します。
+   *
+   * @param publicId 公開用ID
+   * @param email    受講生のメールアドレス
+   * @return true 登録済みの場合、false 未登録の場合
+   */
+  boolean existsByEmailExcludingPublicId(@Param("publicId") String publicId,
+      @Param("email") String email);
 }

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -124,7 +124,13 @@ public class StudentService {
    * @param studentDetail 更新対象の受講生詳細情報
    */
   @Transactional
-  public void updateStudentDetail(StudentDetail studentDetail) {
+  public void updateStudentDetail(StudentDetail studentDetail) throws NotUniqueException {
+    //更新前チェック
+    Student student = studentDetail.getStudent();
+    if (repository.existsByEmailExcludingPublicId(student.getPublicId(), student.getEmail())) {
+      throw new NotUniqueException("このメールアドレスは使用できません。");
+    }
+
     repository.updateStudent(studentDetail.getStudent());
     if (studentDetail.getStudentCourseList() != null) {
       studentDetail.getStudentCourseList()

--- a/src/main/resources/mapper/StudentRepository.xml
+++ b/src/main/resources/mapper/StudentRepository.xml
@@ -74,10 +74,19 @@
     WHERE course_id = #{courseId}
   </update>
 
-  <!-- Emailの重複確認 -->
-  <select id="existsByEmail" parameterType="string">
+  <!-- Emailの重複確認 登録時-->
+  <select id="existsByEmail" resultType="boolean" parameterType="string">
     SELECT COUNT(*) > 0
     FROM students
     WHERE email = #{email}
   </select>
+
+  <!-- Emailの重複確認 更新時-->
+  <select id="existsByEmailExcludingPublicId" parameterType="map" resultType="boolean">
+    SELECT COUNT(*) > 0
+    FROM students
+    WHERE email = #{email}
+    AND public_id != #{publicId}
+  </select>
+
 </mapper>


### PR DESCRIPTION
36_SpringBootでの例外処理
## 追加事項
5a04c038c7fc8f94234526b671e3c5a714e236e0 ：更新処理でのemail重複チェックの導入
　更新処理におけるemail重複チェックの導入
　　・serviceでの重複チェック処理導入とそれに伴うthrowsの追加
　　・repositoryにて更新処理用の重複確認処理の導入

## 実行結果
　正常系
　登録中のメールアドレスのまま送信（emailを変更しない場合）
![image](https://github.com/user-attachments/assets/5baec77b-8e67-4947-b378-e5b13d20dc45)


　異常系
　すでに登録されたメールアドレスで更新処理を実行
![image](https://github.com/user-attachments/assets/fe4bd0fa-ed74-476a-b084-4922ff8d3962)