### PR TITLE
OpenAPI対応のためswagger-ui依存関係と各種アノテーションを追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     //validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    //Open API
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     //Bootstrap
     implementation 'org.webjars:bootstrap:5.3.6'
     //Apache Commons Lang

--- a/src/main/java/raisetech/StudentManagement/StudentManagementApplication.java
+++ b/src/main/java/raisetech/StudentManagement/StudentManagementApplication.java
@@ -1,8 +1,14 @@
 package raisetech.StudentManagement;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+@OpenAPIDefinition(info = @Info(
+    title = "受講生管理システム",
+    description = "受講生に関連する情報を管理するためのシステムです。"
+))
 @SpringBootApplication
 public class StudentManagementApplication {
 

--- a/src/main/java/raisetech/StudentManagement/data/Student.java
+++ b/src/main/java/raisetech/StudentManagement/data/Student.java
@@ -1,5 +1,8 @@
 package raisetech.StudentManagement.data;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -12,18 +15,24 @@ import lombok.Setter;
 import org.springframework.validation.annotation.Validated;
 import raisetech.StudentManagement.validation.RegisterGroup;
 import raisetech.StudentManagement.validation.UpdateGroup;
+import raisetech.StudentManagement.view.RequestViews;
 
 /**
  * 受講生情報を表すエンティティクラスです。 DBのstudentsテーブルに対応します。
  */
+@Schema(description = "受講生情報")
 @Getter
 @Setter
 @Validated
 public class Student {
 
+  @Schema(description = "受講生ID", example = "1")
+  @JsonView(RequestViews.Update.class)
   @Null(groups = RegisterGroup.class, message = "登録時は受講生IDは不要です")
   private Integer studentId;
 
+  @Schema(description = "外部開示用ID(UUID形式)", example = "3ab6f73c-3bc1-11f0-b608-6845f1a11345")
+  @JsonView(RequestViews.Update.class)
   @Null(groups = RegisterGroup.class, message = "登録時はIDは不要です")
   @NotBlank(groups = UpdateGroup.class, message = "更新時はIDは必須です")
   @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
@@ -31,21 +40,29 @@ public class Student {
       message = "入力の形式に誤りがあります")
   private String publicId;
 
+  @Schema(description = "氏名", example = "田中 太郎")
+  @JsonView({RequestViews.Register.class, RequestViews.Update.class})
   @NotBlank(groups = {RegisterGroup.class, UpdateGroup.class},
       message = "名前の入力は必須です")
   @Size(max = 50, groups = {RegisterGroup.class, UpdateGroup.class},
       message = "名前は50文字以内で入力してください")
   private String fullName;
 
+  @Schema(description = "カナ名", example = "タナカ タロウ")
+  @JsonView({RequestViews.Register.class, RequestViews.Update.class})
   @NotBlank(groups = {RegisterGroup.class, UpdateGroup.class}, message = "カナ名の入力は必須です")
   @Size(max = 50, groups = {RegisterGroup.class, UpdateGroup.class},
       message = "カナ名は50文字以内で入力してください")
   private String kanaName;
 
+  @Schema(description = "ニックネーム", example = "たろちゃん")
+  @JsonView({RequestViews.Register.class, RequestViews.Update.class})
   @Size(max = 50, groups = {RegisterGroup.class, UpdateGroup.class},
       message = "ニックネームは50文字以内で入力してください")
   private String nickname;
 
+  @Schema(description = "Email", example = "taro@example.com")
+  @JsonView({RequestViews.Register.class, RequestViews.Update.class})
   @NotBlank(groups = {RegisterGroup.class, UpdateGroup.class},
       message = "メールアドレスの入力は必須です")
   @Email(groups = {RegisterGroup.class, UpdateGroup.class},
@@ -54,24 +71,35 @@ public class Student {
       message = "メールアドレスは50文字以内のアドレスを入力してください")
   private String email;
 
+  @Schema(description = "お住まい", example = "東京都 葛飾区")
+  @JsonView({RequestViews.Register.class, RequestViews.Update.class})
   @Size(max = 50, groups = {RegisterGroup.class, UpdateGroup.class},
       message = "お住まいは50文字以内で入力してください")
   private String region;
 
+  @Schema(description = "年齢", example = "30")
+  @JsonView({RequestViews.Register.class, RequestViews.Update.class})
   @Min(value = 0, groups = {RegisterGroup.class, UpdateGroup.class},
       message = "年齢は0以上の数値を入力してください")
   @Max(value = 150, groups = {RegisterGroup.class, UpdateGroup.class},
       message = "年齢は150以下の数値を入力してください")
   private Integer age;
 
+  @Schema(description = "性別", example = "男性")
+  @JsonView({RequestViews.Register.class, RequestViews.Update.class})
   @Pattern(regexp = "男性|女性|その他|", groups = {RegisterGroup.class, UpdateGroup.class},
       message = "男性・女性・その他 のいずれかを入力してください")
   private String sex;
 
+  @Schema(description = "備考", example = "Javaコース受講検討中")
+  @JsonView({RequestViews.Register.class, RequestViews.Update.class})
   @Size(max = 1000, groups = {RegisterGroup.class, UpdateGroup.class},
       message = "備考は1000文字以内で入力してください")
   private String remark;
 
+  @Schema(name = "isDeleted", description = "論理削除", example = "false")
+  @JsonView(RequestViews.Update.class)
+  @JsonProperty("isDeleted")
   private boolean isDeleted;
 
 }

--- a/src/main/java/raisetech/StudentManagement/data/StudentCourse.java
+++ b/src/main/java/raisetech/StudentManagement/data/StudentCourse.java
@@ -1,5 +1,7 @@
 package raisetech.StudentManagement.data;
 
+import com.fasterxml.jackson.annotation.JsonView;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Null;
@@ -10,32 +12,42 @@ import lombok.Setter;
 import org.springframework.validation.annotation.Validated;
 import raisetech.StudentManagement.validation.RegisterGroup;
 import raisetech.StudentManagement.validation.UpdateGroup;
+import raisetech.StudentManagement.view.RequestViews;
 
 /**
  * 受講コース情報を表すエンティティクラスです。DBのstudents_courseテーブルに対応します。
  */
+@Schema(description = "受講コース情報")
 @Getter
 @Setter
 @Validated
 public class StudentCourse {
 
-  //courseId必須 PRIKEY
+  @Schema(description = "コースID", example = "1")
+  @JsonView(RequestViews.Update.class)
   @Null(groups = RegisterGroup.class, message = "登録時はコースIDは不要です")
   @NotNull(groups = UpdateGroup.class, message = "更新時はコースIDは必須です")
   private Integer courseId;
 
-  //studentId必須 FORKEY
+  @Schema(description = "受講生ID", example = "1")
+  @JsonView(RequestViews.Update.class)
   @Null(groups = RegisterGroup.class, message = "登録時は受講生IDは不要です")
   private Integer studentId;
 
+  @Schema(description = "コース名", example = "AWSコース")
+  @JsonView({RequestViews.Register.class, RequestViews.Update.class})
   @NotBlank(groups = {RegisterGroup.class, UpdateGroup.class},
       message = "コース名の入力は必須です")
   @Size(max = 30, groups = {RegisterGroup.class, UpdateGroup.class},
       message = "コース名は30文字以内で入力してください")
   private String course;
 
+  @Schema(description = "受講開始日", example = "2025-01-01")
+  @JsonView({RequestViews.Register.class, RequestViews.Update.class})
   private LocalDate startDate;
 
+  @Schema(description = "受講終了日", example = "2025-06-30")
+  @JsonView({RequestViews.Register.class, RequestViews.Update.class})
   private LocalDate endDate;
 
 }

--- a/src/main/java/raisetech/StudentManagement/domain/StudentDetail.java
+++ b/src/main/java/raisetech/StudentManagement/domain/StudentDetail.java
@@ -1,5 +1,6 @@
 package raisetech.StudentManagement.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -16,6 +17,7 @@ import raisetech.StudentManagement.validation.UpdateGroup;
 /**
  * 受講生情報（Student）と受講生に紐づく受講コース情報（StudentCourse）をまとめた受講生詳細情報クラスです。 主に画面表示やデータ入出力時のDTOとして使用されます。
  */
+@Schema(description = "受講生詳細情報")
 @Getter
 @Setter
 @AllArgsConstructor
@@ -23,11 +25,13 @@ import raisetech.StudentManagement.validation.UpdateGroup;
 @Validated
 public class StudentDetail {
 
+  @Schema(description = "受講生情報")
   @NotNull(groups = {RegisterGroup.class, UpdateGroup.class},
       message = "受講生情報の入力は必須です。")
   @Valid
   private Student student;
 
+  @Schema(description = "受講コース情報")
   @NotNull(groups = {RegisterGroup.class, UpdateGroup.class},
       message = "登録に必要な情報が不足しています。システム管理者にご連絡ください。")
   @Valid

--- a/src/main/java/raisetech/StudentManagement/exception/response/CustomErrorResponse.java
+++ b/src/main/java/raisetech/StudentManagement/exception/response/CustomErrorResponse.java
@@ -2,6 +2,7 @@ package raisetech.StudentManagement.exception.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.Map;
 import lombok.Getter;
@@ -10,14 +11,31 @@ import org.springframework.http.HttpStatus;
 /**
  * バリデーションエラーやアプリケーション例外が発生した際に、 APIのレスポンスとして返されるエラー情報を表すクラスです。
  */
+@Schema(description = "エラーレスポンス")
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"errorCode", "errorStatus", "message", "fieldErrorMessages"})
 public class CustomErrorResponse {
 
+  @Schema(description = "エラーコード(例：400,404など)", example = "400")
   private int errorCode;
+
+  @Schema(description = "エラーステータス(例：BAD_REQUEST, NOT_FOUND など)", example = "BAD_REQUEST")
   private HttpStatus errorStatus;
+
+  @Schema(description = "一般的なエラーメッセージ。(fieldErrorMessagesとは排他)",
+      example = "受講生情報の取得中に問題が発生しました。")
   private String message;
+
+  @Schema(
+      description = "フィールド毎のエラー内容。キーは対象フィールド名、値はそのフィールドに関連するエラーメッセージの配列。(messageとは排他)",
+      example = """
+          {
+            "fullName": ["名前は必須です", "名前は50文字以内で入力してください"],
+            "email": ["メールアドレスの形式が不正です"]
+          }
+          """
+  )
   private Map<String, List<String>> fieldErrorMessages;
 
   public CustomErrorResponse(HttpStatus status, Map<String, List<String>> fieldErrorMessages) {

--- a/src/main/java/raisetech/StudentManagement/view/RequestViews.java
+++ b/src/main/java/raisetech/StudentManagement/view/RequestViews.java
@@ -1,0 +1,13 @@
+package raisetech.StudentManagement.view;
+
+public class RequestViews {
+
+  public interface Register {
+
+  }
+
+  public interface Update {
+
+  }
+
+}


### PR DESCRIPTION
38_ドキュメントの必要性と作り方
## 実装内容
※前提：フロントエンド開発者向けとして作成
dec9f2b4362318dc1d0a22f9c81f30bd02ec506c ：OpenAPI対応のためswagger-ui依存関係と各種アノテーションを追加

- 　Open API 依存関係を追加
- 　StudentManagementApplication.classに@OpenAPIDefinition追加
- 　Controller各メソッドに@Operationと@ApiResponseを追加
- 　StudentDetailに@Schemaを追加
- 　Student、StudentCourseに@Schemaと@JsonViewを追加
 　　　※@JsonViewで登録処理のRequestBodyに必要項目だけ表示できるようにしました。（各種ID項目とisDeletedは表示対象外）
 　　－ RequestBodyの出力項目制御を行うためのViewを定義するクラス(RequestViews.class)を作成
- 　CustomErrorResponseに@Schemaを追加
 　　　※エラーのレスポンス用に活用するため

**確認事項**
　①Controllerで取りうるレスポンス(成功＋各種エラーレスポンス)をすべて入れたのでボリュームが多くなってしまいましたが、取りうるレスポンスはすべて入れることが望ましいのでしょうか。
　　（フロントエンドで画面作成する際に情報として必要になる可能性を加味して今回はすべて入れてみました）
　
　②エラーレスポンスはコンストラクタが共通で@Schemaのexampleの内容を反映させているため、
　　各種エラー項目に適切なレスポンスを当てることはできていません。
　　その旨descriptionの（）に入れてかつ、CustomErrorResponseの@Schemaにも補足説明もつけたのですが、
　　Example Valueの内容も細かく実際の形式・内容にすることまで求められますでしょうか？
　　※下記はSwaggerのエラーレスポンスの内容
　　　400は実際messageは出ない、404は実際fieldErrorMessageは出ないかつ内容は表示されているものとは異なる
　　　![image](https://github.com/user-attachments/assets/f584bf5d-3b1b-46c1-a8fb-947983448ae3)

## 実行結果
Swagger画面
![localhost_8080_swagger-ui_index html (2)](https://github.com/user-attachments/assets/ef52656b-26c0-4d9f-8e7a-16ecb1298384)

