### PR TITLE
更新処理の例外チェック追加とバリデーションチェックと重複するService層のnullチェック削除

### DIFF
--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -80,10 +80,11 @@ public class StudentService {
 
     //コース情報の登録
     Integer studentId = studentDetail.getStudent().getStudentId();
-    if (studentDetail.getStudentCourseList() != null
-        && !studentDetail.getStudentCourseList().isEmpty()) {
-      registerStudentCourse(studentId, studentDetail.getStudentCourseList());
-    }
+    studentDetail.getStudentCourseList()
+        .forEach(studentCourse -> {
+          registerStudentCourse(studentId, studentDetail.getStudentCourseList());
+        });
+
     return studentDetail;
   }
 
@@ -95,13 +96,10 @@ public class StudentService {
    */
   @Transactional
   public void registerStudentCourse(Integer studentId, List<StudentCourse> studentCourseList) {
-    studentCourseList.stream()
-        .filter(studentCourse -> studentCourse.getCourse() != null && !studentCourse.getCourse()
-            .isEmpty())
-        .forEach(studentCourse -> {
-          initializeStudentCourse(studentId, studentCourse);
-          repository.registerStudentCourse(studentCourse);
-        });
+    studentCourseList.forEach(studentCourse -> {
+      initializeStudentCourse(studentId, studentCourse);
+      repository.registerStudentCourse(studentCourse);
+    });
   }
 
   /**
@@ -136,12 +134,10 @@ public class StudentService {
     }
 
     repository.updateStudent(studentDetail.getStudent());
-    if (studentDetail.getStudentCourseList() != null) {
-      studentDetail.getStudentCourseList()
-          .forEach(studentCourse -> {
-            repository.updateStudentCourse(studentCourse);
-          });
-    }
+    studentDetail.getStudentCourseList()
+        .forEach(studentCourse -> {
+          repository.updateStudentCourse(studentCourse);
+        });
   }
 
 }

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -127,7 +127,11 @@ public class StudentService {
   public void updateStudentDetail(StudentDetail studentDetail) throws NotUniqueException {
     //更新前チェック
     Student student = studentDetail.getStudent();
-    if (repository.existsByEmailExcludingPublicId(student.getPublicId(), student.getEmail())) {
+    String publicId = student.getPublicId();
+    if (repository.searchStudentByPublicId(publicId) == null) {
+      throw new IllegalResourceAccessException(
+          "受講生情報の取得中に問題が発生しました。システム管理者までご連絡ください。");
+    } else if (repository.existsByEmailExcludingPublicId(publicId, student.getEmail())) {
       throw new NotUniqueException("このメールアドレスは使用できません。");
     }
 


### PR DESCRIPTION
## 追加・修正内容

- 0b8a04897c920c24cdba8f9c505d466545dbb07c ：更新時の例外チェックの追加
　修正前：未登録publicIDを渡した場合にemailの重複チェックの例外が投げられる状態
　修正後：未登録publicIDを渡した場合IllegalResourceAccessExceptionを投げシステム例外として処理
　　　　　未登録publicIDを渡す場合はシステム例外であるためemailチェックの前に
　　　　　publicIDが登録済か否かチェックを導入し例外内容の不一致を解消

- 466d042d12ba89ed9ba37fabd654e43e95a3de57 ：バリデーションチェック導入に伴うService不要nullチェックの削除
　バリデーションチェックと重複するnull及びEnptyのチェックコードを削除