### PR TITLE
Feature/39v2

### DIFF
--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -80,10 +80,8 @@ public class StudentService {
 
     //コース情報の登録
     Integer studentId = studentDetail.getStudent().getStudentId();
-    if (studentDetail.getStudentCourseList() != null
-        && !studentDetail.getStudentCourseList().isEmpty()) {
-      registerStudentCourse(studentId, studentDetail.getStudentCourseList());
-    }
+    registerStudentCourse(studentId, studentDetail.getStudentCourseList());
+
     return studentDetail;
   }
 
@@ -95,13 +93,10 @@ public class StudentService {
    */
   @Transactional
   public void registerStudentCourse(Integer studentId, List<StudentCourse> studentCourseList) {
-    studentCourseList.stream()
-        .filter(studentCourse -> studentCourse.getCourse() != null && !studentCourse.getCourse()
-            .isEmpty())
-        .forEach(studentCourse -> {
-          initializeStudentCourse(studentId, studentCourse);
-          repository.registerStudentCourse(studentCourse);
-        });
+    studentCourseList.forEach(studentCourse -> {
+      initializeStudentCourse(studentId, studentCourse);
+      repository.registerStudentCourse(studentCourse);
+    });
   }
 
   /**
@@ -136,12 +131,10 @@ public class StudentService {
     }
 
     repository.updateStudent(studentDetail.getStudent());
-    if (studentDetail.getStudentCourseList() != null) {
-      studentDetail.getStudentCourseList()
-          .forEach(studentCourse -> {
-            repository.updateStudentCourse(studentCourse);
-          });
-    }
+    studentDetail.getStudentCourseList()
+        .forEach(studentCourse -> {
+          repository.updateStudentCourse(studentCourse);
+        });
   }
 
 }

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -127,7 +127,11 @@ public class StudentService {
   public void updateStudentDetail(StudentDetail studentDetail) throws NotUniqueException {
     //更新前チェック
     Student student = studentDetail.getStudent();
-    if (repository.existsByEmailExcludingPublicId(student.getPublicId(), student.getEmail())) {
+    String publicId = student.getPublicId();
+    if (repository.searchStudentByPublicId(publicId) == null) {
+      throw new IllegalResourceAccessException(
+          "受講生情報の取得中に問題が発生しました。システム管理者までご連絡ください。");
+    } else if (repository.existsByEmailExcludingPublicId(publicId, student.getEmail())) {
       throw new NotUniqueException("このメールアドレスは使用できません。");
     }
 


### PR DESCRIPTION
## 追加・修正内容

- 0b8a04897c920c24cdba8f9c505d466545dbb07c ：更新時の例外チェックの追加
　修正前：未登録publicIDを渡した場合にemailの重複チェックの例外が投げられる状態
　修正後：未登録publicIDを渡した場合IllegalResourceAccessExceptionを投げシステム例外として処理
　　　　　未登録publicIDを渡す場合はシステム例外であるためemailチェックの前に
　　　　　publicIDが登録済か否かチェックを導入し例外内容の不一致を解消

- 721debcda186e3ce0eb64c9d610a48e765e8292c ：バリデーションチェック導入に伴うService不要nullチェックの削除
　バリデーションチェックと重複するnull及びEnptyのチェックコードを削除
　
## 実行結果
未登録publicIDで更新処理
![image](https://github.com/user-attachments/assets/3a918a96-aa20-49fa-95ea-50b448d54eba)

nullチェック削除の影響確認
①studentDetail.studentCourseList == nullの場合　バリデーションエラー
![image](https://github.com/user-attachments/assets/4abc8032-fe4e-41f5-a1b9-bd225e51693c)

②studentDetail.studentCourseList == Emptyの場合　正常処理
![image](https://github.com/user-attachments/assets/f7d2de29-44eb-406c-9783-eafcaff01ee1)

③studentCourse == null バリデーションエラー
![image](https://github.com/user-attachments/assets/0521323e-bb21-4fc0-975a-bfeedf42566a)

④studentCourse == 空 バリデーションエラー
![image](https://github.com/user-attachments/assets/8ce7a9b2-00f8-4587-a55d-ca220a8f684e)
