### PR TITLE
更新時の例外チェックの追加とバリデーションチェックと重複するService層の分岐処理の削除

### DIFF
--- a/src/main/java/raisetech/StudentManagement/domain/StudentDetail.java
+++ b/src/main/java/raisetech/StudentManagement/domain/StudentDetail.java
@@ -37,7 +37,7 @@ public class StudentDetail {
   @Schema(description = "受講コース情報")
   @JsonView({RequestViews.Register.class, RequestViews.Update.class})
   @NotNull(groups = {RegisterGroup.class, UpdateGroup.class},
-      message = "登録に必要な情報が不足しています。システム管理者にご連絡ください。")
+      message = "登録・更新処理に必要な情報が不足しています。システム管理者にご連絡ください。")
   @Valid
   private List<StudentCourse> studentCourseList;
 

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -80,10 +80,8 @@ public class StudentService {
 
     //コース情報の登録
     Integer studentId = studentDetail.getStudent().getStudentId();
-    if (studentDetail.getStudentCourseList() != null
-        && !studentDetail.getStudentCourseList().isEmpty()) {
-      registerStudentCourse(studentId, studentDetail.getStudentCourseList());
-    }
+    registerStudentCourse(studentId, studentDetail.getStudentCourseList());
+
     return studentDetail;
   }
 
@@ -95,13 +93,10 @@ public class StudentService {
    */
   @Transactional
   public void registerStudentCourse(Integer studentId, List<StudentCourse> studentCourseList) {
-    studentCourseList.stream()
-        .filter(studentCourse -> studentCourse.getCourse() != null && !studentCourse.getCourse()
-            .isEmpty())
-        .forEach(studentCourse -> {
-          initializeStudentCourse(studentId, studentCourse);
-          repository.registerStudentCourse(studentCourse);
-        });
+    studentCourseList.forEach(studentCourse -> {
+      initializeStudentCourse(studentId, studentCourse);
+      repository.registerStudentCourse(studentCourse);
+    });
   }
 
   /**
@@ -136,12 +131,10 @@ public class StudentService {
     }
 
     repository.updateStudent(studentDetail.getStudent());
-    if (studentDetail.getStudentCourseList() != null) {
-      studentDetail.getStudentCourseList()
-          .forEach(studentCourse -> {
-            repository.updateStudentCourse(studentCourse);
-          });
-    }
+    studentDetail.getStudentCourseList()
+        .forEach(studentCourse -> {
+          repository.updateStudentCourse(studentCourse);
+        });
   }
 
 }

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -127,7 +127,11 @@ public class StudentService {
   public void updateStudentDetail(StudentDetail studentDetail) throws NotUniqueException {
     //更新前チェック
     Student student = studentDetail.getStudent();
-    if (repository.existsByEmailExcludingPublicId(student.getPublicId(), student.getEmail())) {
+    String publicId = student.getPublicId();
+    if (repository.searchStudentByPublicId(publicId) == null) {
+      throw new IllegalResourceAccessException(
+          "受講生情報の取得中に問題が発生しました。システム管理者までご連絡ください。");
+    } else if (repository.existsByEmailExcludingPublicId(publicId, student.getEmail())) {
       throw new NotUniqueException("このメールアドレスは使用できません。");
     }
 


### PR DESCRIPTION
## 追加・修正内容

- 0b8a04897c920c24cdba8f9c505d466545dbb07c ：更新時の例外チェックの追加
　修正前：未登録publicIDを渡した場合にemailの重複チェックの例外が投げられる状態
　修正後：未登録publicIDを渡した場合IllegalResourceAccessExceptionを投げシステム例外として処理
　　　　　未登録publicIDを渡す場合はシステム例外であるためemailチェックの前に
　　　　　publicIDが登録済か否かチェックを導入し例外内容の不一致を解消

- 8149ae544058c726375301709ac4c8495a443711：バリデーションチェック導入に伴うService不要nullチェックの削除
　バリデーションチェックと重複するnull及びEnptyのチェックコードを削除
　エラーメッセージの修正
　
## 実行結果
未登録publicIDで更新処理
![image](https://github.com/user-attachments/assets/3a918a96-aa20-49fa-95ea-50b448d54eba)

nullチェック削除の影響確認
①登録処理　studentDetail.studentCourseList == nullの場合　バリデーションエラー
![image](https://github.com/user-attachments/assets/ee14e445-11aa-43d7-a81a-932cb203a717)

②登録処理　studentDetail.studentCourseList == Emptyの場合　正常処理
![image](https://github.com/user-attachments/assets/7ee3616c-67cb-4f00-b42c-955ff422ba2f)

③登録処理　studentCourse == null バリデーションエラー
![image](https://github.com/user-attachments/assets/35cb4922-58e8-4f24-998e-5709e2a3cb9f)

④登録処理　studentCourse == 空 バリデーションエラー
![image](https://github.com/user-attachments/assets/d3d0f231-69e0-45aa-a1c4-68dec496ce6f)


⑤更新処理　studentDetail.studentCourseList == nullの場合　バリデーションエラー
![image](https://github.com/user-attachments/assets/26194207-59e9-4228-9eb2-5cbad0e2f91b)

