### PR TITLE
repositoryテストの実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ dependencies {
     //Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    //MyBatis Test
+    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
+    //H2(inMemoryDB)
+    testImplementation 'com.h2database:h2:2.3.232'
 
     providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/raisetech/StudentManagement/data/Student.java
+++ b/src/main/java/raisetech/StudentManagement/data/Student.java
@@ -10,7 +10,9 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Null;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.validation.annotation.Validated;
 import raisetech.StudentManagement.validation.RegisterGroup;
@@ -24,6 +26,8 @@ import raisetech.StudentManagement.view.RequestViews;
 @Getter
 @Setter
 @Validated
+@NoArgsConstructor
+@AllArgsConstructor
 public class Student {
 
   @Schema(description = "受講生ID", example = "1")

--- a/src/main/java/raisetech/StudentManagement/data/StudentCourse.java
+++ b/src/main/java/raisetech/StudentManagement/data/StudentCourse.java
@@ -7,7 +7,9 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Null;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.validation.annotation.Validated;
 import raisetech.StudentManagement.validation.RegisterGroup;
@@ -21,6 +23,8 @@ import raisetech.StudentManagement.view.RequestViews;
 @Getter
 @Setter
 @Validated
+@NoArgsConstructor
+@AllArgsConstructor
 public class StudentCourse {
 
   @Schema(description = "コースID", example = "1")

--- a/src/test/java/raisetech/StudentManagement/repository/StudentRepositoryTest.java
+++ b/src/test/java/raisetech/StudentManagement/repository/StudentRepositoryTest.java
@@ -1,0 +1,249 @@
+package raisetech.StudentManagement.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import raisetech.StudentManagement.data.Student;
+import raisetech.StudentManagement.data.StudentCourse;
+
+@MybatisTest
+class StudentRepositoryTest {
+
+  @Autowired
+  private StudentRepository sut;
+
+  //受講生全件取得（論理削除は除く)
+  @Test
+  void DBのstudentsテーブル内でisDeletedがfalseのデータのみ取得できていること() {
+    List<Student> actual = sut.searchStudentList();
+
+    assertThat(actual.size()).isEqualTo(5);
+    assertThat(actual)
+        .allSatisfy(student -> assertThat(student.isDeleted()).isEqualTo(false));
+  }
+
+  //受講コース全件検索
+  @Test
+  void DBのstudentsCoursesテーブル内で全件のデータが取得できていること() {
+    List<StudentCourse> actual = sut.searchStudentCourseList();
+
+    assertThat(actual.size()).isEqualTo(7);
+  }
+
+  //publicIDに基づく受講生個人検索:publicId登録あり
+  @Test
+  void 受講生の個人検索でpublicIdが一致する受講生情報が取得できていること() {
+    String publicId = "3ab6f73c-3bc1-11f0-b608-6845f1a11345";
+
+    Student actual = sut.searchStudentByPublicId(publicId);
+
+    assertThat(actual.getPublicId()).isEqualTo(publicId);
+  }
+
+  //publicIDに基づく受講生個人検索:publicId登録なし
+  @Test
+  void 受講生の個人検索でpublicIdが一致する受講生情報が存在しない場合nullが返ること() {
+    String publicId = "00000000-0000-0000-0000-000000000000";
+
+    Student actual = sut.searchStudentByPublicId(publicId);
+
+    assertThat(actual).isNull();
+  }
+
+  //studentIDに基づく受講コース検索:複数コースあり
+  @Test
+  void 検索したstudentIDのコース情報を登録個数分取得できていること() {
+    Integer studentId = 1;
+
+    List<StudentCourse> actual = sut.searchStudentCourseListByStudentId(studentId);
+
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual)
+        .allSatisfy(course -> assertThat(course.getStudentId()).isEqualTo(studentId));
+  }
+
+  //studentIDに基づく受講コース検索:Idに紐づく登録コースなし
+  @Test
+  void 検索したstudentIDのと紐づくコース情報が存在しない場合に空リストが返ること() {
+    Integer studentId = 3;
+
+    List<StudentCourse> actual = sut.searchStudentCourseListByStudentId(studentId);
+
+    assertThat(actual).isEmpty();
+  }
+
+  //受講生登録処理
+  @Test
+  void 受講生登録処理実行後に受講生の全項目が登録されかつ引数のstudentに発効されたstudentIdがsetされていること() {
+    Student student = new Student(
+        null,
+        "5f7b71c1-9012-4a9d-89a2-9d0f9b7eabcd",
+        "山田 太郎",
+        "ヤマダ タロウ",
+        "たっちゃん",
+        "taro.yamada@example.org",
+        "福岡県 北九州市",
+        28,
+        "その他",
+        "Java受講予定です",
+        false
+    );
+
+    sut.registerStudent(student);
+
+    Student registeredStudent = sut.searchStudentByPublicId(student.getPublicId());
+
+    assertThat(registeredStudent)
+        .usingRecursiveComparison()
+        .isEqualTo(student);
+  }
+
+  //受講コース登録処理
+  @Test
+  void コース登録処理実行後にコースの全項目が登録されかつ引数のstudentCourseに発効されたcourseIdがsetされていること() {
+    StudentCourse studentCourse = new StudentCourse(
+        null,
+        1,
+        "AIコース",
+        LocalDate.of(2025, 7, 1),
+        LocalDate.of(2025, 2, 1)
+    );
+
+    sut.registerStudentCourse(studentCourse);
+
+    List<StudentCourse> studentCourseList = sut.searchStudentCourseListByStudentId(
+        studentCourse.getStudentId());
+
+    assertThat(studentCourseList)
+        .usingRecursiveFieldByFieldElementComparator()
+        .contains(studentCourse);
+  }
+
+  //受講生更新処理：更新対応項目の更新確認
+  @Test
+  void 受講生更新処理実行後に受講生のID項目以外の全項目が更新されること() {
+    String publicId = "3ab6f73c-3bc1-11f0-b608-6845f1a11345";
+    Student student = sut.searchStudentByPublicId(publicId);
+    //studentのID項目以外すべて変更
+    student.setFullName("テスト 一朗");
+    student.setKanaName("テスト イチロウ");
+    student.setNickname("テスト");
+    student.setEmail("XXX@XXX.XXX");
+    student.setRegion("XX県 XXX市");
+    student.setAge(100);
+    student.setSex("その他");
+    student.setRemark("XXXコース受講");
+    student.setDeleted(true);
+
+    sut.updateStudent(student);
+
+    Student updatedStudent = sut.searchStudentByPublicId(publicId);
+
+    assertThat(updatedStudent)
+        .usingRecursiveComparison()
+        .isEqualTo(student);
+  }
+
+  //受講生更新処理：更新非対応項目の未更新確認
+  @Test
+  void 受講生情報のstudentIdを更新した場合にstudentIdに変更が反映されないこと() {
+    String publicId = "3ab6f73c-3bc1-11f0-b608-6845f1a11345";
+    Student student = sut.searchStudentByPublicId(publicId);
+    //検証用に元のIDを保持
+    Integer originalStudentId = student.getStudentId();
+    student.setStudentId(999);
+
+    sut.updateStudent(student);
+
+    Student updatedStudent = sut.searchStudentByPublicId(publicId);
+
+    assertThat(updatedStudent.getStudentId()).isEqualTo(originalStudentId);
+  }
+
+  //受講コース更新処理：更新対応項目の更新確認
+  @Test
+  void 受講コース更新処理実行後にコースのID項目以外の全項目が更新されること() {
+    Integer studentId = 2;
+    LocalDate now = LocalDate.now();
+    StudentCourse studentCourse = sut.searchStudentCourseListByStudentId(studentId).getFirst();
+    //studentCourseのID項目以外すべて変更
+    studentCourse.setCourse("XXXコース");
+    studentCourse.setStartDate(now);
+    studentCourse.setEndDate(now.plusMonths(6));
+
+    sut.updateStudentCourse(studentCourse);
+
+    StudentCourse updatedStudentCourse = sut.searchStudentCourseListByStudentId(studentId)
+        .getFirst();
+
+    assertThat(updatedStudentCourse)
+        .usingRecursiveComparison()
+        .isEqualTo(studentCourse);
+  }
+
+  //受講コース更新処理：：更新非対応項目の未更新確認
+  @Test
+  void 受講コース情報のstudentIdを更新した場合にstudentIdに変更が反映されないこと() {
+    Integer studentId = 2;
+    StudentCourse studentCourse = sut.searchStudentCourseListByStudentId(studentId).getFirst();
+    studentCourse.setStudentId(1);
+
+    sut.updateStudentCourse(studentCourse);
+
+    StudentCourse updatedStudentCourse = sut.searchStudentCourseListByStudentId(studentId)
+        .getFirst();
+
+    //処理前後のコースIDの一致を検証することで、対象受講生に紐づくコース情報が変更されていないことを検証
+    assertThat(updatedStudentCourse.getCourseId()).isEqualTo(studentCourse.getCourseId());
+  }
+
+
+  //メースアドレスの重複チェック(チェック対象：全レコード）※登録処理を想定
+  @Test
+  void 登録済みemaliで実行した場合にtrueが返ること() {
+    boolean actual = sut.existsByEmail("taro@example.com");
+
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  void 登録済みemaliで照合した場合にfalseが返ること() {
+    boolean actual = sut.existsByEmail("Test@example");
+
+    assertThat(actual).isFalse();
+  }
+
+  //メールアドレスの重複チェック(チェック対象：更新対象レコード以外）※更新処理を想定
+  @Test
+  void 更新対象受講生以外の受講生情報に登録されているemailを照合した結果trueが返ること() {
+    String publicId = "3ab6f73c-3bc1-11f0-b608-6845f1a11345";
+
+    boolean actual = sut.existsByEmailExcludingPublicId(publicId, "hanako@example.com");
+
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  void 更新対象受講生のemailと同じemailで照合した結果falseが返ること() {
+    String publicId = "3ab6f73c-3bc1-11f0-b608-6845f1a11345";
+
+    boolean actual = sut.existsByEmailExcludingPublicId(publicId, "taro@example.com");
+
+    assertThat(actual).isFalse();
+  }
+
+  @Test
+  void 未登録のemailで照合した結果falseが返ること() {
+    String publicId = "3ab6f73c-3bc1-11f0-b608-6845f1a11345";
+
+    boolean actual = sut.existsByEmailExcludingPublicId(publicId, "XXX@XXX.XXX");
+
+    assertThat(actual).isFalse();
+  }
+
+
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,10 @@
+spring.application.name=StudentManagement
+spring.sql.init.mode=always
+spring.datasource.url=jdbc:h2:~/test;MODE=MySQL
+spring.datasource.username=sa
+spring.datasource.password=sa
+spring.datasource.driver-class-name=org.h2.Driver
+spring.h2.console.enabled=true
+# MyBatis
+mybatis.configuration.map-underscore-to-camel-case=true
+mybatis.mapper-locations=classpath:/mapper/*.xml

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,0 +1,26 @@
+
+INSERT INTO students (
+  public_id, full_name, kana_name, nickname, email, region, age, sex, remark, is_deleted
+) VALUES
+-- 全データ含むレコード
+('3ab6f73c-3bc1-11f0-b608-6845f1a11345', '田中 太郎', 'タナカ タロウ', 'たろちゃん', 'taro@example.com', '東京都 葛飾区', 30, '男性', 'Javaコース受講検討中', FALSE),
+-- 最低限データ + 空データ
+('d8a0a2f1-7e5e-4f0f-b123-a1b3d1f82dd2', '佐藤 花子', 'サトウ ハナコ', '', 'hanako@example.com', '', NULL, '', '', FALSE),
+-- 最低限データ + NULLデータ
+('e5f734ac-7c44-43e4-9aef-2dc1cb246aa1', '井上 翔', 'イノウエ ショウ', NULL, 'sho@example.com', NULL, NULL, NULL, NULL, FALSE),
+('c7f92318-bb9e-4a9b-908b-c5a8aaf3f378', '中村 悠', 'ナカムラ ユウ', 'ゆう', 'yuu@example.com', '北海道 札幌市', 22, '女性', 'Pythonとデータ分析に関心があります。統計や機械学習にも取り組みたいです。', FALSE),
+('b77c3c35-d43a-4f9e-bb7a-55871a6c2b7e', '鈴木 孝', 'スズキ タカシ', 'たかさん', 'takashi@example.com', '長野県 松本市', 72, 'その他', 'リスキリングとしてJavaを学習中', FALSE),
+-- 論理削除=TRUE
+('9a30b7b0-5e1b-4ac5-a7de-d2c3c1bfa382', '田中 太郎', 'タナカ タロウ', NULL, 'tanaka2@example.com', NULL, 40, '男性', 'すでに退会済の受講生', TRUE);
+
+INSERT INTO students_courses (
+  student_id, course, start_date, end_date
+) VALUES
+(1, 'Javaコース', '2025-01-10', '2025-07-10'),
+(1, 'JavaScriptコース', '2025-04-15', '2025-10-15'),
+(2, 'Pythonコース', '2025-02-01', '2025-08-01'),
+(4, 'Pythonコース', NULL, NULL),
+(5, 'Javaコース', '2025-01-20', '2025-08-20'),
+(5, 'AWSコース', '2025-04-01', '2026-02-01'),
+(6, 'AWSコース', '2025-01-01', '2026-08-01');
+-- studentId=3のみ紐づく登録コース無し

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,0 +1,24 @@
+CREATE TABLE students (
+  student_id INT PRIMARY KEY AUTO_INCREMENT,
+  public_id VARCHAR(36) NOT NULL,
+  full_name VARCHAR(50) NOT NULL,
+  kana_name VARCHAR(50) NOT NULL,
+  nickname VARCHAR(50),
+  email VARCHAR(50) NOT NULL,
+  region VARCHAR(50),
+  age INT,
+  sex VARCHAR(10),
+  remark VARCHAR(1000) DEFAULT '',
+  is_deleted BOOLEAN DEFAULT FALSE,
+  UNIQUE (public_id),
+  UNIQUE (email)
+);
+
+CREATE TABLE students_courses (
+  course_id INT PRIMARY KEY AUTO_INCREMENT,
+  student_id INT NOT NULL,
+  course VARCHAR(30) NOT NULL,
+  start_date DATE,
+  end_date DATE,
+  FOREIGN KEY (student_id) REFERENCES students(student_id)
+);


### PR DESCRIPTION
43_RepositoryのテストとConverterのテスト解説

## 実装内容
158ca5c7b8597e2ffb34061f3e2d92e44369522c ：repositoryテストの実装
・依存関係の追加：MyBatis Test と H2 BD
・テスト用application.propertiesの追加
・schema.sql / data.sql の追加
・repositoryテストクラスの作成（StudentRepositoryTest.class）
・その他：Student,StudentCourseクラスにコンストラクタのアノテーションを追加

ーーテストケース
| No | テスト対象 | 条件 | 補足 |
| --- | --- | --- | --- |
| 1 | 受講生全件取得 |  | 論理削除済みは含まない  |
| 2 | 受講コース全件取得 |  |  |
| 3 | 受講生個人取得 | 対象IDの受講生情報**あり** |  |
| 4 | ↓ | 対象IDの受講生情報**なし** |  |
| 5 | コース情報1人分取得 | 対象IDに紐づくコース情報**あり** |  |
| 6 | ↓ | 対象IDに紐づくコース情報**なし** |  |
| 7 | 受講生登録 |  |  |
| 8 | コース登録 |  |  |
| 9 | 受講生更新 | 更新**可**項目の更新確認 |  |
| 10 | ↓ | 更新**不可**項目の更新**不可**確認 |  |
| 11 | コース更新 | 更新**可**項目の更新確認 |  |
| 12 | ↓ | 更新**不可**項目の更新**不可**確認 |  |
| 13 | email重複確認(登録前) | 重複**あり**時の挙動確認 |  |
| 14 | ↓ | 重複**なし**時の挙動確認 |  |
| 15 | email重複確認(更新前) | 重複**あり**時の挙動確認 | 自身以外の登録済みemailで照合 |
| 16 | ↓ | 重複**なし**時の挙動確認 | 自身の登録済みemailで照合 |
| 17 | ↓ | 重複**なし**時の挙動確認 | DB未登録emailで照合 |

補足
登録処理、更新処理の確認は全項目が正しく処理されているか検証する形にしました。
（xmlでカラムの抜け漏れを確認するため)