### PR TITLE
全件検索機能を条件検索機能に改修

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -12,12 +12,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import raisetech.StudentManagement.domain.StudentDetail;
+import raisetech.StudentManagement.domain.criteria.SearchCriteria;
 import raisetech.StudentManagement.exception.custom.NotUniqueException;
 import raisetech.StudentManagement.exception.response.CustomErrorResponse;
 import raisetech.StudentManagement.service.StudentService;
@@ -46,7 +48,7 @@ public class StudentController {
    *
    * @return 受講生詳細情報のリスト
    */
-  @Operation(summary = "受講生詳細一覧を取得", description = "受講生詳細情報の一覧を取得します。（但し、キャンセル扱いの受講生は除きます。）")
+  @Operation(summary = "受講生詳細一覧を取得", description = "検索条件に一致する受講生詳細情報の一覧を取得します。（但し、キャンセル扱いの受講生は除きます。）")
   @ApiResponse(
       responseCode = "200",
       description = "リクエストが正常に処理された場合",
@@ -57,17 +59,24 @@ public class StudentController {
       )
   )
   @ApiResponse(
-      responseCode = "500",
-      description = "サーバー内部で予期しないエラーが発生した場合<br>"
-          + "（まだ未実装のため形式・内容が異なる可能性かあります。）",
+      responseCode = "400",
+      description = "リクエストパラメータがバリデーションルールに適合しない場合<br>"
+          + "(errorCord,errorStatus,messageまたはfieldErrorMessagesが返ります。)",
       content = @Content(
           mediaType = "application/json",
           schema = @Schema(implementation = CustomErrorResponse.class)
       )
   )
+  @ApiResponse(
+      responseCode = "500",
+      description = "サーバー内部で予期しないエラーが発生した場合<br>"
+          + "（まだ未実装のため形式・内容が異なる可能性かあります。）",
+      content = @Content()
+  )
   @GetMapping("/studentList")
-  public List<StudentDetail> getStudentList() {
-    return service.searchStudentDetailList();
+  public List<StudentDetail> getStudentDetailList(
+      @Validated @ModelAttribute SearchCriteria criteria) {
+    return service.searchStudentDetailList(criteria);
   }
 
   /**

--- a/src/main/java/raisetech/StudentManagement/domain/criteria/SearchCriteria.java
+++ b/src/main/java/raisetech/StudentManagement/domain/criteria/SearchCriteria.java
@@ -1,0 +1,72 @@
+package raisetech.StudentManagement.domain.criteria;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * 受講生詳細検の一覧取得において、条件検索を行うための検索対象項目を定義するクラスです。
+ */
+@Schema(description = "受講生詳細一覧検索の全検索条件")
+@Getter
+@Builder
+@Validated
+public class SearchCriteria {
+
+  //Student項目
+  @Schema(description = "氏名の検索値（部分一致で検索）", example = "田中")
+  @Size(max = 50, message = "氏名の検索値は50文字以内で入力してください")
+  private String fullName;
+
+  @Schema(description = "カナ名の検索値（部分一致で検索）", example = "タナカ")
+  @Pattern(regexp = "^[ぁ-んァ-ヶｦ-ﾟー\\s\u3000]*$",
+      message = "カナ名の検索値は ひらがな・カタカナ、またはスペースのみを入力してください")
+  @Size(max = 50, message = "カナ名の検索値は50文字以内で入力してください")
+  private String kanaName;
+
+  @Schema(description = "emailの検索値（完全一致で検索）", example = "tanaka@exampl.com")
+  @Email(message = "Emailは完全一致検索です。正しいメールアドレスの形式で入力してください")
+  @Size(max = 50, message = "emailの検索値は50文字以内で入力してください")
+  private String email;
+
+  @Schema(description = "お住まいの検索値（部分一致で検索）", example = "東京都")
+  @Size(max = 50, message = "お住まいの検索値は50文字以内で入力してください")
+  private String region;
+
+  @Schema(description = "年齢の検索範囲の下限値", example = "18")
+  @Min(value = 0, message = "年齢の検索値は0以上で入力してください")
+  @Max(value = 150, message = "年齢の検索値は150以下で入力してください")
+  private Integer minAge;
+
+  @Schema(description = "年齢の検索範囲の上限値", example = "50")
+  @Min(value = 0, message = "年齢の検索値は0以上で入力してください")
+  @Max(value = 150, message = "年齢の検索値は150以下で入力してください")
+  private Integer maxAge;
+
+  @Schema(description = "性別の検索値（完全一致で検索）", example = "男性")
+  @Pattern(regexp = "男性|女性|その他", message = "性別の検索値は 男性・女性・その他 のいずれかで入力してください")
+  private String sex;
+
+  //StudentCourse項目
+  @Schema(description = "コース名の検索値（部分一致で検索）", example = "Javaコース")
+  @Size(max = 30, message = "コース名の検索値は30文字以内で入力してください")
+  private String course;
+
+  //CourseStatus項目
+  @Schema(description = "コース申込ステータスの検索値（完全一致で検索）", example = "仮申込")
+  @Pattern(regexp = "仮申込|本申込|受講中|受講終了|キャンセル",
+      message = "ステータスは 仮申込・本申込・受講中・受講終了・キャンセル のいずれかで入力してください")
+  private String status;
+
+  public boolean hasCourseOrStatus() {
+    return StringUtils.hasText(course) || StringUtils.hasText(status);
+  }
+
+}

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -6,6 +6,7 @@ import org.apache.ibatis.annotations.Param;
 import raisetech.StudentManagement.data.CourseStatus;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.domain.criteria.SearchCriteria;
 
 /**
  * 受講生情報および受講コース情報及びコース申込ステータスに関するDBアクセス処理を定義するリポジトリインターフェースです。
@@ -15,25 +16,25 @@ import raisetech.StudentManagement.data.StudentCourse;
 public interface StudentRepository {
 
   /**
-   * 全受講生の情報を取得します。(但し、キャンセル扱い(isDeleted=true)の受講生は除きます）
+   * 検索条件に合致する受講生の情報を取得します。(但し、キャンセル扱い(isDeleted=true)の受講生は除きます）
    *
    * @return 受講生情報（Student）のリスト
    */
-  List<Student> searchStudentList();
+  List<Student> searchStudentList(SearchCriteria criteria);
 
   /**
-   * 全受講生の全受講コース情報を取得します。
+   * 検索条件に合致する受講コース情報を取得します。
    *
    * @return 受講コース情報（StudentCourse）のリスト
    */
-  List<StudentCourse> searchStudentCourseList();
+  List<StudentCourse> searchStudentCourseList(SearchCriteria criteria);
 
   /**
-   * 全コース申込ステータス情報を取得します。
+   * 検索条件に合致するコース申込ステータス情報を取得します。
    *
    * @return コース申込スタータス情報（CourseStatus）のリスト
    */
-  List<CourseStatus> searchCourseStatusList();
+  List<CourseStatus> searchCourseStatusList(SearchCriteria criteria);
 
   /**
    * publicIdに対応した受講生情報を取得します。

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -62,7 +62,7 @@ public class StudentService {
     }
 
     //CourseDetailに関連する検索項目がない場合はStudentDetailのCourseDetailList=Emptyを許容する
-    return converter.convertToStudentDetail(studentList, courseDetailList);
+    return converter.toStudentDetailFromAllStudents(studentList, courseDetailList);
   }
 
   SearchCriteria normalizeCriteria(SearchCriteria original) {

--- a/src/main/java/raisetech/StudentManagement/service/converter/StudentConverter.java
+++ b/src/main/java/raisetech/StudentManagement/service/converter/StudentConverter.java
@@ -18,9 +18,10 @@ import raisetech.StudentManagement.domain.StudentDetail;
 public class StudentConverter {
 
   /**
-   * 受講生リストとコース詳細情報リストから受講生詳細情報のリストに変換するconverterです。 受講生詳細情報は受講生情報を基に作成されます。
+   * 受講生リストとコース詳細情報リストから受講生詳細情報のリストに変換するconverterです。
+   * すべての受講生を対象とし、紐づくコース詳細情報が存在する場合はその情報を、存在しない場合は空のリストを用いて受講生詳細情報を構築します。
    */
-  public List<StudentDetail> convertToStudentDetail(List<Student> studentList,
+  public List<StudentDetail> toStudentDetailFromAllStudents(List<Student> studentList,
       List<CourseDetail> courseDetailList) {
 
     return studentList.stream()

--- a/src/main/java/raisetech/StudentManagement/service/converter/StudentConverter.java
+++ b/src/main/java/raisetech/StudentManagement/service/converter/StudentConverter.java
@@ -33,6 +33,24 @@ public class StudentConverter {
   }
 
   /**
+   * 受講生リストとコース詳細情報リストから受講生詳細情報のリストに変換するconverterです。
+   * 受講生の内、studentIdで紐づくコース詳細情報が存在する場合のみStudentDetailに変換しリストに含めます。
+   */
+  public List<StudentDetail> toStudentDetailFromStudentsWithCourse(
+      List<Student> studentList, List<CourseDetail> courseDetailList) {
+
+    Map<Integer, List<CourseDetail>> coursesMap = courseDetailList.stream()
+        .collect(
+            Collectors.groupingBy(courseDetail -> courseDetail.getStudentCourse().getStudentId()));
+
+    return studentList.stream()
+        .filter(student -> coursesMap.containsKey(student.getStudentId()))
+        .map(student -> new StudentDetail(student,
+            coursesMap.getOrDefault(student.getStudentId(), List.of())))
+        .toList();
+  }
+
+  /**
    * 受講コースリストとコース申込ステータスリストからコース詳細情報のリストに変換するconverterです。
    * 両リストに同じcourseIdのデータが存在するレコードのみをコース詳細情報に変換しリストに含めます。
    */

--- a/src/main/java/raisetech/StudentManagement/service/normalizer/SearchCriteriaNormalizer.java
+++ b/src/main/java/raisetech/StudentManagement/service/normalizer/SearchCriteriaNormalizer.java
@@ -1,0 +1,35 @@
+package raisetech.StudentManagement.service.normalizer;
+
+import java.text.Normalizer;
+import org.springframework.stereotype.Component;
+
+/**
+ * 検索条件SearchCriteriaの各項目を検索可能な形式に変換するクラスです
+ */
+@Component
+public class SearchCriteriaNormalizer {
+
+  /**
+   * カナ名の検索文字列について平仮名と半角カタカナを角カタカナに、またスペースはすべて半角に変換します。
+   */
+  public String kanaNameNormalize(String kanaName) {
+    if (kanaName == null || kanaName.isEmpty()) {
+      return kanaName;
+    }
+
+    // 半角 → 全角（スペースは半角）の正規化
+    String normalizedKanaName = Normalizer.normalize(kanaName, Normalizer.Form.NFKC);
+
+    // ひらがな → カタカナ
+    StringBuilder builder = new StringBuilder();
+    for (char c : normalizedKanaName.toCharArray()) {
+      if (c >= 'ぁ' && c <= 'ゖ') {
+        builder.append((char) (c + 0x60));
+      } else {
+        builder.append(c);
+      }
+    }
+
+    return builder.toString();
+  }
+}

--- a/src/main/resources/mapper/StudentRepository.xml
+++ b/src/main/resources/mapper/StudentRepository.xml
@@ -4,19 +4,55 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="raisetech.StudentManagement.repository.StudentRepository">
-  <!-- 全受講生の情報を取得（キャンセルは除外） -->
-  <select id="searchStudentList" resultType="raisetech.StudentManagement.data.Student">
-    SELECT * FROM students WHERE is_deleted = false
+  <!-- 検索条件に合致する受講生の情報を取得（キャンセルは除外） -->
+  <select id="searchStudentList"
+    parameterType="raisetech.StudentManagement.domain.criteria.SearchCriteria"
+    resultType="raisetech.StudentManagement.data.Student">
+    SELECT * FROM students
+    WHERE is_deleted = false
+    <if test="fullName != null and fullName != ''">
+      AND full_Name LIKE CONCAT('%', #{fullName}, '%')
+    </if>
+    <if test="kanaName != null and kanaName != ''">
+      AND kana_name LIKE CONCAT('%', #{kanaName}, '%')
+    </if>
+    <if test="email != null and email != ''">
+      AND email = #{email}
+    </if>
+    <if test="region != null and region != ''">
+      AND region LIKE CONCAT('%', #{region}, '%')
+    </if>
+    <if test="minAge != null">
+      AND age &gt;= #{minAge}
+    </if>
+    <if test="maxAge != null">
+      AND age &lt;= #{maxAge}
+    </if>
+    <if test="sex != null and sex != ''">
+      AND sex = #{sex}
+    </if>
   </select>
 
-  <!-- 全受講コース情報を取得 -->
-  <select id="searchStudentCourseList" resultType="raisetech.StudentManagement.data.StudentCourse">
+  <!-- 検索条件に合致する受講コース情報を取得 -->
+  <select id="searchStudentCourseList"
+    parameterType="raisetech.StudentManagement.domain.criteria.SearchCriteria"
+    resultType="raisetech.StudentManagement.data.StudentCourse">
     SELECT * FROM students_courses
+    WHERE 1 = 1
+    <if test="course != null and course != ''">
+      AND course LIKE CONCAT('%', #{course}, '%')
+    </if>
   </select>
 
-  <!-- 全コース申込ステータス情報を取得 -->
-  <select id="searchCourseStatusList" resultType="raisetech.StudentManagement.data.CourseStatus">
+  <!-- 検索条件に合致するコース申込ステータス情報を取得 -->
+  <select id="searchCourseStatusList"
+    parameterType="raisetech.StudentManagement.domain.criteria.SearchCriteria"
+    resultType="raisetech.StudentManagement.data.CourseStatus">
     SELECT * FROM course_status
+    WHERE 1 = 1
+    <if test="status != null and status != ''">
+      AND status = #{status}
+    </if>
   </select>
 
   <!-- PublicId による受講生情報の取得 -->

--- a/src/test/java/raisetech/StudentManagement/controller/SearchCriteriaValidationTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/SearchCriteriaValidationTest.java
@@ -1,0 +1,66 @@
+package raisetech.StudentManagement.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import raisetech.StudentManagement.domain.criteria.SearchCriteria;
+
+public class SearchCriteriaValidationTest {
+
+  @Autowired
+  private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+  //検索条件：正常系
+  @Test
+  void 検索条件の入力チェックで異常が発生しないこと() {
+    SearchCriteria criteria = SearchCriteria.builder()
+        .fullName("太郎")
+        .kanaName("タロウ")
+        .email("tanaka@example.com")
+        .region("東京")
+        .minAge(18)
+        .maxAge(50)
+        .sex("男性")
+        .course("Javaコース")
+        .status("受講中")
+        .build();
+
+    Set<ConstraintViolation<SearchCriteria>> violations = validator.validate(criteria);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest
+  @MethodSource("searchCriteriaValidPattern")
+  void 検索条件のテストケースについて入力チェックで一つの異常が発生すること(SearchCriteria criteria,
+      String message) {
+
+    Set<ConstraintViolation<SearchCriteria>> violations = validator.validate(criteria);
+
+    assertThat(violations.size()).isEqualTo(1);
+    assertThat(violations).extracting("message").contains(message);
+  }
+
+  private static Stream<Arguments> searchCriteriaValidPattern() {
+    return Stream.of(
+        Arguments.of(SearchCriteria.builder().fullName("a".repeat(51)).build(),
+            "氏名の検索値は50文字以内で入力してください"),
+        Arguments.of(SearchCriteria.builder().kanaName("田中").build(),
+            "カナ名の検索値は ひらがな・カタカナ、またはスペースのみを入力してください"),
+        Arguments.of(SearchCriteria.builder().email("tanaka").build(),
+            "Emailは完全一致検索です。正しいメールアドレスの形式で入力してください"),
+        Arguments.of(SearchCriteria.builder().maxAge(1500).build(),
+            "年齢の検索値は150以下で入力してください")
+    );
+  }
+
+}

--- a/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
@@ -1,5 +1,6 @@
 package raisetech.StudentManagement.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -11,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -21,6 +23,7 @@ import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
 import raisetech.StudentManagement.domain.CourseDetail;
 import raisetech.StudentManagement.domain.StudentDetail;
+import raisetech.StudentManagement.domain.criteria.SearchCriteria;
 import raisetech.StudentManagement.exception.converter.ErrorResponseConverter;
 import raisetech.StudentManagement.service.StudentService;
 import raisetech.StudentManagement.testdata.TestDataFactory;
@@ -40,14 +43,22 @@ class StudentControllerTest {
   @MockitoBean
   private ErrorResponseConverter errorResponseConverter;
 
-  //受講生全件検索：正常系
+  //受講生詳細条件検索：正常系
   @Test
-  void 受講生全件検索実行時に正常に処理が実行され適切なServiceが呼び出されていること()
+  void 受講生詳細条件検索実行時に正常に処理が実行され適切なServiceが呼び出されていること()
       throws Exception {
-    mockMvc.perform(get("/studentList"))
+    SearchCriteria expected = SearchCriteria.builder()
+        .fullName("田中")
+        .build();
+
+    mockMvc.perform(get("/studentList")
+            .param("fullName", "田中"))
         .andExpect(status().isOk());
 
-    verify(service, times(1)).searchStudentDetailList();
+    ArgumentCaptor<SearchCriteria> captor = ArgumentCaptor.forClass(SearchCriteria.class);
+
+    verify(service, times(1)).searchStudentDetailList(captor.capture());
+    assertThat(captor.getValue()).usingRecursiveComparison().isEqualTo(expected);
   }
 
   //受講生個人検索：正常系

--- a/src/test/java/raisetech/StudentManagement/repository/StudentRepositoryTest.java
+++ b/src/test/java/raisetech/StudentManagement/repository/StudentRepositoryTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import raisetech.StudentManagement.data.CourseStatus;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.domain.criteria.SearchCriteria;
 
 @MybatisTest
 class StudentRepositoryTest {
@@ -17,30 +18,183 @@ class StudentRepositoryTest {
   @Autowired
   private StudentRepository sut;
 
-  //受講生全件取得（論理削除は除く)
+  //受講生条件検索：検索条件なしで受講生全件取得（論理削除は除く)
   @Test
-  void DBのstudentsテーブル内でisDeletedがfalseのデータのみ取得できていること() {
-    List<Student> actual = sut.searchStudentList();
+  void 検索条件なしでDBのstudentsテーブル内でisDeletedがfalseのデータのみ取得できていること() {
+    SearchCriteria criteria = SearchCriteria.builder().build();
+    List<Student> actual = sut.searchStudentList(criteria);
 
     assertThat(actual.size()).isEqualTo(5);
     assertThat(actual)
         .allSatisfy(student -> assertThat(student.isDeleted()).isEqualTo(false));
   }
 
-  //受講コース全件検索
+  //受講生条件検索：単独検索(Student.fullName：部分一致)
+  @Test
+  void fullNameの検索で適切な検索結果が返ってくること() {
+    String fullName = "太郎";
+    SearchCriteria criteria = SearchCriteria.builder()
+        .fullName(fullName)
+        .build();
+
+    List<Student> actual = sut.searchStudentList(criteria);
+
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual)
+        .allSatisfy(student -> assertThat(student.getFullName()).contains(fullName));
+  }
+
+  //受講生条件検索：単独検索(Student.kanaName：部分一致)
+  @Test
+  void kanaName検索で適切な検索結果が返ってくること() {
+    String kanaName = "タロ";
+    SearchCriteria criteria = SearchCriteria.builder()
+        .kanaName(kanaName)
+        .build();
+
+    List<Student> actual = sut.searchStudentList(criteria);
+
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual)
+        .allSatisfy(student -> assertThat(student.getKanaName()).contains(kanaName));
+  }
+
+  //受講生条件検索：単独検索(Student.email：完全一致)
+  @Test
+  void email検索で適切な検索結果が返ってくること() {
+    String email = "suzuki@example.com";
+    SearchCriteria criteria = SearchCriteria.builder()
+        .email(email)
+        .build();
+
+    List<Student> actual = sut.searchStudentList(criteria);
+
+    assertThat(actual.size()).isEqualTo(1);
+    assertThat(actual.getFirst().getEmail()).isEqualTo(email);
+  }
+
+  //受講生条件検索：単独検索(Student.region：部分一致)
+  @Test
+  void region検索で適切な検索結果が返ってくること() {
+    String region = "都";
+    SearchCriteria criteria = SearchCriteria.builder()
+        .region(region)
+        .build();
+
+    List<Student> actual = sut.searchStudentList(criteria);
+
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual)
+        .allSatisfy(student -> assertThat(student.getRegion()).contains(region));
+  }
+
+  //受講生条件検索：単独検索(Student.age：対象数値以上)
+  @Test
+  void minAge検索で適切な検索結果が返ってくること() {
+    Integer minAge = 30;
+    SearchCriteria criteria = SearchCriteria.builder()
+        .minAge(minAge)
+        .build();
+
+    List<Student> actual = sut.searchStudentList(criteria);
+
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual)
+        .allSatisfy(student -> assertThat(student.getAge()).isGreaterThanOrEqualTo(minAge));
+  }
+
+  //受講生条件検索：単独検索(Student.age：対象数値以下)
+  @Test
+  void maxAge検索で適切な検索結果が返ってくること() {
+    Integer maxAge = 30;
+    SearchCriteria criteria = SearchCriteria.builder()
+        .maxAge(maxAge)
+        .build();
+
+    List<Student> actual = sut.searchStudentList(criteria);
+
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual)
+        .allSatisfy(student -> assertThat(student.getAge()).isLessThanOrEqualTo(maxAge));
+  }
+
+  //受講生条件検索：単独検索(Student.sex：完全一致)
+  @Test
+  void sex検索で適切な検索結果が返ってくること() {
+    String sex = "女性";
+    SearchCriteria criteria = SearchCriteria.builder()
+        .sex(sex)
+        .build();
+
+    List<Student> actual = sut.searchStudentList(criteria);
+
+    assertThat(actual.size()).isEqualTo(1);
+    assertThat(actual.getFirst().getSex()).isEqualTo(sex);
+  }
+
+  //受講生条件検索：複数条件検索(Student.age：規定範囲内)
+  @Test
+  void minAgeとmaxAgeの間の年齢のみ検索結果として返ってくること() {
+    Integer minAge = 29;
+    Integer maxAge = 31;
+    SearchCriteria criteria = SearchCriteria.builder()
+        .minAge(minAge)
+        .maxAge(maxAge)
+        .build();
+
+    List<Student> actual = sut.searchStudentList(criteria);
+
+    assertThat(actual.size()).isEqualTo(1);
+    assertThat(actual.getFirst().getAge()).isLessThanOrEqualTo(maxAge);
+    assertThat(actual.getFirst().getAge()).isGreaterThanOrEqualTo(minAge);
+  }
+
+  //受講コース条件検索:検索条件なしで全受講コース取得
   @Test
   void DBのstudentsCoursesテーブル内で全件のデータが取得できていること() {
-    List<StudentCourse> actual = sut.searchStudentCourseList();
+    SearchCriteria criteria = SearchCriteria.builder().build();
+    List<StudentCourse> actual = sut.searchStudentCourseList(criteria);
 
     assertThat(actual.size()).isEqualTo(8);
   }
 
-  //コース申込ステータス全件検索
+  //受講コース条件検索：単独検索(StudentCourse.course：部分一致)
+  @Test
+  void course検索で適切な検索結果が返ってくること() {
+    String course = "Python";
+    SearchCriteria criteria = SearchCriteria.builder()
+        .course(course)
+        .build();
+
+    List<StudentCourse> actual = sut.searchStudentCourseList(criteria);
+
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual)
+        .allSatisfy(student -> assertThat(student.getCourse()).contains(course));
+  }
+
+  //コース申込ステータス条件検索:検索条件なしで全コース申込ステータス取得
   @Test
   void DBのCourseStatusテーブル内で全件のデータが取得できていること() {
-    List<CourseStatus> actual = sut.searchCourseStatusList();
+    SearchCriteria criteria = SearchCriteria.builder().build();
+    List<CourseStatus> actual = sut.searchCourseStatusList(criteria);
 
     assertThat(actual.size()).isEqualTo(7);
+  }
+
+  //コース申込ステータス条件検索：単独検索(CourseStatus.status：完全一致)
+  @Test
+  void status検索で適切な検索結果が返ってくること() {
+    String status = "キャンセル";
+    SearchCriteria criteria = SearchCriteria.builder()
+        .status(status)
+        .build();
+
+    List<CourseStatus> actual = sut.searchCourseStatusList(criteria);
+
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual)
+        .allSatisfy(student -> assertThat(student.getStatus()).isEqualTo(status));
   }
 
   //publicIDに基づく受講生個人検索:publicId登録あり

--- a/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
@@ -91,7 +91,7 @@ class StudentServiceTest {
     verify(converter, times(1))
         .convertToCourseDetail(studentsCourseList, courseStatusList);
     verify(converter, times(1))
-        .convertToStudentDetail(studentList, courseDetailList);
+        .toStudentDetailFromAllStudents(studentList, courseDetailList);
     //repositoryの引数が正規化後のcriteriaであることの検証
     List<SearchCriteria> criteriaList = captor.getAllValues();
     assertThat(criteriaList)
@@ -120,7 +120,7 @@ class StudentServiceTest {
     verify(converter, times(1))
         .toStudentDetailFromStudentsWithCourse(studentList, courseDetailList);
     verify(converter, never())
-        .convertToStudentDetail(anyList(), anyList());
+        .toStudentDetailFromAllStudents(anyList(), anyList());
   }
 
   //受講生詳細条件検索：正常系:検索条件と合致する受講生なし

--- a/src/test/java/raisetech/StudentManagement/service/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/converter/StudentConverterTest.java
@@ -94,6 +94,63 @@ class StudentConverterTest {
     assertThat(actual).isEmpty();
   }
 
+  //toStudentDetailFromStudentsWithCourse：データ組み替え検証
+  @Test
+  void リスト中の受講生で紐づくコース詳細情報が存在する場合のみStudentDetailを生成しリスト化できていること() {
+    //前準備
+    Student student888 = createStudentWithStudentId(888);
+    Student student999 = createStudentWithStudentId(999);
+
+    StudentCourse student888Course1 = createCourseWithStudentId(888);
+    StudentCourse student888Course2 = createCourseWithStudentId(888);
+    StudentCourse noiseCourse = createCourseWithStudentId(1999);
+
+    CourseDetail courseDetail888Course1 = new CourseDetail(student888Course1, new CourseStatus());
+    CourseDetail courseDetail888Course2 = new CourseDetail(student888Course2, new CourseStatus());
+    CourseDetail courseDetailNoiseCourse = new CourseDetail(noiseCourse, new CourseStatus());
+
+    List<Student> studentList = List.of(student888, student999);
+    List<CourseDetail> courseDetailList = List.of(courseDetail888Course1, courseDetail888Course2,
+        courseDetailNoiseCourse);
+
+    //期待値の設定
+    StudentDetail expectStudentDetail888 = new StudentDetail(student888,
+        List.of(courseDetail888Course1, courseDetail888Course2));
+
+    //実行
+    List<StudentDetail> actual = sut.toStudentDetailFromStudentsWithCourse(studentList,
+        courseDetailList);
+
+    //検証
+    assertThat(actual)
+        .hasSize(1)
+        .containsExactly(expectStudentDetail888);
+  }
+
+  @Test
+  void コース詳細情報リストが空の場合に空のリストが返されていること() {
+    List<Student> studentList = List.of(createStudentWithStudentId(999));
+    List<CourseDetail> courseDetailList = List.of();
+
+    List<StudentDetail> actual = sut.toStudentDetailFromStudentsWithCourse(studentList,
+        courseDetailList);
+
+    //検証
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void 受講生情報リストが空の場合に空のリストが返されていること() {
+    List<Student> studentList = List.of();
+    List<CourseDetail> courseDetailList = List.of(
+        new CourseDetail(createCourseWithStudentId(999), new CourseStatus()));
+
+    List<StudentDetail> actual = sut
+        .toStudentDetailFromStudentsWithCourse(studentList, courseDetailList);
+
+    assertThat(actual).isEmpty();
+  }
+
   //convertToCourseDetail:データの組み換え検証
   @Test
   void 受講コースとコース申込ステータスのリストから両リストに同じcourseID持つレコードのみをCourseDetailに変換しリスト化して返されること() {

--- a/src/test/java/raisetech/StudentManagement/service/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/converter/StudentConverterTest.java
@@ -20,9 +20,9 @@ class StudentConverterTest {
     sut = new StudentConverter();
   }
 
-  //convertToStudentDetail:データの組み換え検証
+  //toStudentDetailFromAllStudents:データの組み換え検証
   @Test
-  void 受講生リストと受講コース詳細リストからstudentIDに基づき適切なStudentDetailが返されること() {
+  void リスト中の全受講生に対し適切なコース詳細情報を割り当てたStudentDetailを生成しリスト化できていること() {
     //前準備
     Student student777 = createStudentWithStudentId(777);
     Student student888 = createStudentWithStudentId(888);
@@ -52,7 +52,7 @@ class StudentConverterTest {
         expectStudentDetail888, expectStudentDetail999);
 
     //実行
-    List<StudentDetail> actual = sut.convertToStudentDetail(studentList, courseDetailList);
+    List<StudentDetail> actual = sut.toStudentDetailFromAllStudents(studentList, courseDetailList);
 
     //検証
     assertThat(actual.size()).isEqualTo(expectStudentDetailList.size());
@@ -67,7 +67,7 @@ class StudentConverterTest {
 
     List<StudentDetail> expectStudentDetailList = List.of(new StudentDetail(student, List.of()));
 
-    List<StudentDetail> actual = sut.convertToStudentDetail(studentList, courseDetailList);
+    List<StudentDetail> actual = sut.toStudentDetailFromAllStudents(studentList, courseDetailList);
 
     assertThat(actual.size()).isEqualTo(expectStudentDetailList.size());
     assertThat(actual).isEqualTo(expectStudentDetailList);
@@ -79,7 +79,7 @@ class StudentConverterTest {
     List<CourseDetail> courseDetailList = List.of(
         new CourseDetail(createCourseWithStudentId(999), new CourseStatus()));
 
-    List<StudentDetail> actual = sut.convertToStudentDetail(studentList, courseDetailList);
+    List<StudentDetail> actual = sut.toStudentDetailFromAllStudents(studentList, courseDetailList);
 
     assertThat(actual).isEmpty();
   }
@@ -89,7 +89,7 @@ class StudentConverterTest {
     List<Student> studentList = List.of();
     List<CourseDetail> courseDetailList = List.of();
 
-    List<StudentDetail> actual = sut.convertToStudentDetail(studentList, courseDetailList);
+    List<StudentDetail> actual = sut.toStudentDetailFromAllStudents(studentList, courseDetailList);
 
     assertThat(actual).isEmpty();
   }

--- a/src/test/java/raisetech/StudentManagement/service/normalizer/SearchCriteriaNormalizerTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/normalizer/SearchCriteriaNormalizerTest.java
@@ -1,0 +1,53 @@
+package raisetech.StudentManagement.service.normalizer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SearchCriteriaNormalizerTest {
+
+  private SearchCriteriaNormalizer sut;
+
+  @BeforeEach
+  void setUp() {
+    sut = new SearchCriteriaNormalizer();
+  }
+
+  @Test
+  void nullを渡すとnullが返る() {
+    String actual = sut.kanaNameNormalize(null);
+    assertThat(actual).isNull();
+  }
+
+  @Test
+  void 半角カナは全角カナに正規化される() {
+    String result = sut.kanaNameNormalize("ｶﾀｶﾅｱﾝ");
+    assertThat(result).isEqualTo("カタカナアン");
+  }
+
+  @Test
+  void ひらがなは全角カタカナに変換される() {
+    String result = sut.kanaNameNormalize("ひらがなぁゖ");
+    assertThat(result).isEqualTo("ヒラガナァヶ");
+  }
+
+  @Test
+  void 全角カタカナと記号はそのまま返る() {
+    String result = sut.kanaNameNormalize("カタカナァヶー");
+    assertThat(result).isEqualTo("カタカナァヶー");
+  }
+
+  @Test
+  void 全角スペースは半角スペースに変換される() {
+    String result = sut.kanaNameNormalize("　 ");  //全角スペース1 + 半角スペース1
+    assertThat(result).isEqualTo("  ");
+  }
+
+  @Test
+  void 入力形式の混在時はすべて全角カタカナに変換される() {
+    String result = sut.kanaNameNormalize("ｶﾀｶﾅひらがなカタカナ");
+    assertThat(result).isEqualTo("カタカナヒラガナカタカナ");
+  }
+
+}

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -8,8 +8,8 @@ INSERT INTO students (
 ('d8a0a2f1-7e5e-4f0f-b123-a1b3d1f82dd2', '佐藤 花子', 'サトウ ハナコ', '', 'hanako@example.com', '', NULL, '', '', FALSE),
 -- 最低限データ + NULLデータ
 ('e5f734ac-7c44-43e4-9aef-2dc1cb246aa1', '井上 翔', 'イノウエ ショウ', NULL, 'sho@example.com', NULL, NULL, NULL, NULL, FALSE),
-('c7f92318-bb9e-4a9b-908b-c5a8aaf3f378', '中村 悠', 'ナカムラ ユウ', 'ゆう', 'yuu@example.com', '北海道 札幌市', 22, '女性', 'Pythonとデータ分析に関心があります。統計や機械学習にも取り組みたいです。', FALSE),
-('b77c3c35-d43a-4f9e-bb7a-55871a6c2b7e', '鈴木 孝', 'スズキ タカシ', 'たかさん', 'takashi@example.com', '長野県 松本市', 100, 'その他', 'リスキリングとしてJavaを学習中', FALSE),
+('c7f92318-bb9e-4a9b-908b-c5a8aaf3f378', '中村 悠', 'ナカムラ ユウ', 'ゆう', 'yuu@example.com', '東京都 港区', 22, '女性', 'Pythonとデータ分析に関心があります。統計や機械学習にも取り組みたいです。', FALSE),
+('b77c3c35-d43a-4f9e-bb7a-55871a6c2b7e', '鈴木 太郎', 'スズキ タロウ', 'たかさん', 'suzuki@example.com', '長野県 松本市', 100, 'その他', 'リスキリングとしてJavaを学習中', FALSE),
 -- 論理削除=TRUE
 ('9a30b7b0-5e1b-4ac5-a7de-d2c3c1bfa382', '田中 太郎', 'タナカ タロウ', NULL, 'tanaka2@example.com', NULL, 40, '男性', 'すでに退会済の受講生', TRUE);
 --補足：studentId=2は更新処理のテスト対象として使用


### PR DESCRIPTION
44_検索条件の追加と申込み状況機能の追加
課題：
　申し込み状況機能の追加　（作成・提出済み）
　検索条件の追加　　　　　（本PR対象）

## 実装内容
5f9739d7860e3ffb091b0b6691903a36ed58215d：受講生検索処理の実装（受講生全件検索を改修）
1fabfde617e16b68a0f1267a43336ad90b01be6f ：converterのリファクタリング

### 詳細
### 受講生検索処理の実装
- **SearchCriteria.class**：検索条件の項目を定義するクラスとして作成しました。
　　― ageは範囲検索できる様上限値・下限値の二つのfieldを持たせました。
　　ー カナ名はプログラム内でカナ変換する仕様とし、下記文字種のみ許容します。
　　　　ひらがな、カタカナ、半角カタカナ、ー、スペース

- **Controller** ：全件検索メソッドを条件検索メソッドに改修
　　－API仕様書に400エラー追加

- **Service**：全件検索メソッドを条件検索メソッドに改修
　　－検索条件は、normalizeCriteriaにて正規化（カナ名のみ正規化対応）
　　－処理工程の見直し

- **Converter**：条件検索対応の新規のStudentDetailconverterを実装。
　　ー新規のStudentDetailのconverterは受講生に紐づくコース情報がある場合のみStudnetDetailを作成
　　　　→受講コースと申込状況の検索条件が**ある**場合はコース情報は必須であり新converterを適用
　　※従来のStudentDetailのconverterはコース詳細の空を許容しStudentDetailを作成
　　　　→受講コースと申込状況の検索条件が**ない**場合は従来converterを適用しコース詳細の空を許容

- **SearchCriteriaNormalizer** ：検索条件を、検索処理が可能な形式に変換する処理をまとめたクラス
　　－カナ名の検索値を全角カナor半角スペースに変換する処理を導入
 　　　（現在DBのカナ名の登録値の氏・名間は半スぺなのでその様式に合わせた変換になっています）
　　　※本来は登録時に文字種に制限をかけるべきなので別途対応予定です

- **Repository**：全件検索の各種メソッドを条件検索メソッドに改修

- メインの各クラス変更に伴い、各対応クラスのテストの修正・追加

- SearchCriteriaNormalizerのテストクラスの追加（各変換パターンで変換できているか検証）

- SearchCriteriaのバリデーションテストクラスの追加（代表的なバリデーションについて検証）

**converterのリファクタリング**
- 新規converterのメソッド名や処理内容と従来converterメソッドを差別化できるように
　メソッド名およびテスト名を修正しました。

補足：
・SearchCriteriaのage範囲指定で下限値>上限値時のバリデーション導入を検討しましたが、現状実装はしていません。（必要に応じて今後実装予定）

**確認事項**　
①Serviceのテスとについて： https://github.com/Lika-H210/StudentManagement/commit/5f9739d7860e3ffb091b0b6691903a36ed58215d#r162302707
上記リンク箇所のテストについて、確認いただきたい内容記載しています。
テストの方法が問題ないかご確認ご回答いただけますと幸いです。

## 実行確認

