### PR TITLE
全件検索機能を条件検索機能に改修

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -12,12 +12,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import raisetech.StudentManagement.domain.StudentDetail;
+import raisetech.StudentManagement.domain.condition.SearchCondition;
 import raisetech.StudentManagement.exception.custom.NotUniqueException;
 import raisetech.StudentManagement.exception.response.CustomErrorResponse;
 import raisetech.StudentManagement.service.StudentService;
@@ -42,11 +44,13 @@ public class StudentController {
   }
 
   /**
-   * 受講生の詳細情報一覧を取得します。(但し、キャンセル扱い(isDeleted=true)の受講生は除きます）
+   * 検索条件と合致する受講生の詳細情報一覧を取得します。検索条件の指定がない場合は全受講生の受講生の受講生詳細情報を取得します。
+   * (但し、キャンセル扱い(isDeleted=true)の受講生は除きます）
    *
+   * @param condition 検索条件
    * @return 受講生詳細情報のリスト
    */
-  @Operation(summary = "受講生詳細一覧を取得", description = "受講生詳細情報の一覧を取得します。（但し、キャンセル扱いの受講生は除きます。）")
+  @Operation(summary = "受講生詳細一覧を取得", description = "検索条件に一致する受講生詳細情報の一覧を取得します。（但し、キャンセル扱いの受講生は除きます。）")
   @ApiResponse(
       responseCode = "200",
       description = "リクエストが正常に処理された場合",
@@ -57,17 +61,24 @@ public class StudentController {
       )
   )
   @ApiResponse(
-      responseCode = "500",
-      description = "サーバー内部で予期しないエラーが発生した場合<br>"
-          + "（まだ未実装のため形式・内容が異なる可能性かあります。）",
+      responseCode = "400",
+      description = "リクエストパラメータがバリデーションルールに適合しない場合<br>"
+          + "(errorCord,errorStatus,messageまたはfieldErrorMessagesが返ります。)",
       content = @Content(
           mediaType = "application/json",
           schema = @Schema(implementation = CustomErrorResponse.class)
       )
   )
+  @ApiResponse(
+      responseCode = "500",
+      description = "サーバー内部で予期しないエラーが発生した場合<br>"
+          + "（まだ未実装のため形式・内容が異なる可能性かあります。）",
+      content = @Content()
+  )
   @GetMapping("/studentList")
-  public List<StudentDetail> getStudentList() {
-    return service.searchStudentDetailList();
+  public List<StudentDetail> getStudentDetailList(
+      @Validated @ModelAttribute SearchCondition condition) {
+    return service.searchStudentDetailList(condition);
   }
 
   /**

--- a/src/main/java/raisetech/StudentManagement/domain/condition/SearchCondition.java
+++ b/src/main/java/raisetech/StudentManagement/domain/condition/SearchCondition.java
@@ -1,0 +1,72 @@
+package raisetech.StudentManagement.domain.condition;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * 受講生詳細検の一覧取得において、条件検索を行うための検索対象項目を定義するクラスです。
+ */
+@Schema(description = "受講生詳細一覧検索の全検索条件")
+@Getter
+@Builder
+@Validated
+public class SearchCondition {
+
+  //Student項目
+  @Schema(description = "氏名の検索値（部分一致で検索）", example = "田中")
+  @Size(max = 50, message = "氏名の検索値は50文字以内で入力してください")
+  private String fullName;
+
+  @Schema(description = "カナ名の検索値（部分一致で検索）", example = "タナカ")
+  @Pattern(regexp = "^[ぁ-んァ-ヶｦ-ﾟー\\s\u3000]*$",
+      message = "カナ名の検索値は ひらがな・カタカナ、またはスペースのみを入力してください")
+  @Size(max = 50, message = "カナ名の検索値は50文字以内で入力してください")
+  private String kanaName;
+
+  @Schema(description = "emailの検索値（完全一致で検索）", example = "tanaka@exampl.com")
+  @Email(message = "Emailは完全一致検索です。正しいメールアドレスの形式で入力してください")
+  @Size(max = 50, message = "emailの検索値は50文字以内で入力してください")
+  private String email;
+
+  @Schema(description = "お住まいの検索値（部分一致で検索）", example = "東京都")
+  @Size(max = 50, message = "お住まいの検索値は50文字以内で入力してください")
+  private String region;
+
+  @Schema(description = "年齢の検索範囲の下限値", example = "18")
+  @Min(value = 0, message = "年齢の検索値は0以上で入力してください")
+  @Max(value = 150, message = "年齢の検索値は150以下で入力してください")
+  private Integer minAge;
+
+  @Schema(description = "年齢の検索範囲の上限値", example = "50")
+  @Min(value = 0, message = "年齢の検索値は0以上で入力してください")
+  @Max(value = 150, message = "年齢の検索値は150以下で入力してください")
+  private Integer maxAge;
+
+  @Schema(description = "性別の検索値（完全一致で検索）", example = "男性")
+  @Pattern(regexp = "男性|女性|その他", message = "性別の検索値は 男性・女性・その他 のいずれかで入力してください")
+  private String sex;
+
+  //StudentCourse項目
+  @Schema(description = "コース名の検索値（部分一致で検索）", example = "Javaコース")
+  @Size(max = 30, message = "コース名の検索値は30文字以内で入力してください")
+  private String course;
+
+  //CourseStatus項目
+  @Schema(description = "コース申込ステータスの検索値（完全一致で検索）", example = "仮申込")
+  @Pattern(regexp = "仮申込|本申込|受講中|受講終了|キャンセル",
+      message = "ステータスは 仮申込・本申込・受講中・受講終了・キャンセル のいずれかで入力してください")
+  private String status;
+
+  public boolean hasCourseOrStatus() {
+    return StringUtils.hasText(course) || StringUtils.hasText(status);
+  }
+
+}

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -6,6 +6,7 @@ import org.apache.ibatis.annotations.Param;
 import raisetech.StudentManagement.data.CourseStatus;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.domain.condition.SearchCondition;
 
 /**
  * 受講生情報および受講コース情報及びコース申込ステータスに関するDBアクセス処理を定義するリポジトリインターフェースです。
@@ -15,25 +16,28 @@ import raisetech.StudentManagement.data.StudentCourse;
 public interface StudentRepository {
 
   /**
-   * 全受講生の情報を取得します。(但し、キャンセル扱い(isDeleted=true)の受講生は除きます）
+   * 検索条件に合致する受講生の情報を取得します。(但し、キャンセル扱い(isDeleted=true)の受講生は除きます）
    *
+   * @param condition 検索条件
    * @return 受講生情報（Student）のリスト
    */
-  List<Student> searchStudentList();
+  List<Student> searchStudentList(SearchCondition condition);
 
   /**
-   * 全受講生の全受講コース情報を取得します。
+   * 検索条件に合致する受講コース情報を取得します。
    *
+   * @param condition 検索条件
    * @return 受講コース情報（StudentCourse）のリスト
    */
-  List<StudentCourse> searchStudentCourseList();
+  List<StudentCourse> searchStudentCourseList(SearchCondition condition);
 
   /**
-   * 全コース申込ステータス情報を取得します。
+   * 検索条件に合致するコース申込ステータス情報を取得します。
    *
+   * @param condition 検索条件
    * @return コース申込スタータス情報（CourseStatus）のリスト
    */
-  List<CourseStatus> searchCourseStatusList();
+  List<CourseStatus> searchCourseStatusList(SearchCondition condition);
 
   /**
    * publicIdに対応した受講生情報を取得します。

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -62,7 +62,7 @@ public class StudentService {
     }
 
     //CourseDetailに関連する検索項目がない場合はStudentDetailのCourseDetailList=Emptyを許容する
-    return converter.convertToStudentDetail(studentList, courseDetailList);
+    return converter.toStudentDetailFromAllStudents(studentList, courseDetailList);
   }
 
   SearchCondition SearchConditionFormatter(SearchCondition original) {

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -2,6 +2,7 @@ package raisetech.StudentManagement.service;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,10 +13,12 @@ import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
 import raisetech.StudentManagement.domain.CourseDetail;
 import raisetech.StudentManagement.domain.StudentDetail;
+import raisetech.StudentManagement.domain.condition.SearchCondition;
 import raisetech.StudentManagement.exception.custom.IllegalResourceAccessException;
 import raisetech.StudentManagement.exception.custom.NotUniqueException;
 import raisetech.StudentManagement.repository.StudentRepository;
 import raisetech.StudentManagement.service.converter.StudentConverter;
+import raisetech.StudentManagement.service.formatter.SearchConditionFormatter;
 
 /**
  * 受講生の詳細情報に関する検索・登録・更新などの業務ロジックを提供するサービスクラスです。 受講生情報、受講コース情報、コース申込ステータス情報が対象になります。
@@ -25,11 +28,14 @@ public class StudentService {
 
   private StudentRepository repository;
   private StudentConverter converter;
+  private SearchConditionFormatter formatter;
 
   @Autowired
-  public StudentService(StudentRepository repository, StudentConverter converter) {
+  public StudentService(StudentRepository repository, StudentConverter converter,
+      SearchConditionFormatter formatter) {
     this.repository = repository;
     this.converter = converter;
+    this.formatter = formatter;
   }
 
   /**
@@ -37,13 +43,40 @@ public class StudentService {
    *
    * @return 受講生詳細情報のリスト
    */
-  public List<StudentDetail> searchStudentDetailList() {
-    List<Student> studentList = repository.searchStudentList();
-    List<StudentCourse> studentsCourseList = repository.searchStudentCourseList();
-    List<CourseStatus> courseStatusList = repository.searchCourseStatusList();
+  public List<StudentDetail> searchStudentDetailList(SearchCondition condition) {
+    SearchCondition formattedCondition = SearchConditionFormatter(condition);
+
+    List<Student> studentList = repository.searchStudentList(formattedCondition);
+    if (studentList.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<StudentCourse> studentsCourseList = repository.searchStudentCourseList(formattedCondition);
+    List<CourseStatus> courseStatusList = repository.searchCourseStatusList(formattedCondition);
     List<CourseDetail> courseDetailList = converter.convertToCourseDetail(studentsCourseList,
         courseStatusList);
+
+    //CourseDetailに関連する検索項目がある場合はStudentDetailのCourseDetailList=Emptyは許容されない
+    if (condition.hasCourseOrStatus()) {
+      return converter.toStudentDetailFromStudentsWithCourse(studentList, courseDetailList);
+    }
+
+    //CourseDetailに関連する検索項目がない場合はStudentDetailのCourseDetailList=Emptyを許容する
     return converter.convertToStudentDetail(studentList, courseDetailList);
+  }
+
+  SearchCondition SearchConditionFormatter(SearchCondition original) {
+    return SearchCondition.builder()
+        .fullName(original.getFullName())
+        .kanaName(formatter.kanaNameFormatter(original.getKanaName()))
+        .email(original.getEmail())
+        .region(original.getRegion())
+        .minAge(original.getMinAge())
+        .maxAge(original.getMaxAge())
+        .sex(original.getSex())
+        .course(original.getCourse())
+        .status(original.getStatus())
+        .build();
   }
 
   /**

--- a/src/main/java/raisetech/StudentManagement/service/converter/StudentConverter.java
+++ b/src/main/java/raisetech/StudentManagement/service/converter/StudentConverter.java
@@ -18,9 +18,10 @@ import raisetech.StudentManagement.domain.StudentDetail;
 public class StudentConverter {
 
   /**
-   * 受講生リストとコース詳細情報リストから受講生詳細情報のリストに変換するconverterです。 受講生詳細情報は受講生情報を基に作成されます。
+   * 受講生リストとコース詳細情報リストから受講生詳細情報のリストに変換するconverterです。
+   * すべての受講生を対象とし、紐づくコース詳細情報が存在する場合はその情報を、存在しない場合は空のリストを用いて受講生詳細情報を構築します。
    */
-  public List<StudentDetail> convertToStudentDetail(List<Student> studentList,
+  public List<StudentDetail> toStudentDetailFromAllStudents(List<Student> studentList,
       List<CourseDetail> courseDetailList) {
 
     return studentList.stream()

--- a/src/main/java/raisetech/StudentManagement/service/converter/StudentConverter.java
+++ b/src/main/java/raisetech/StudentManagement/service/converter/StudentConverter.java
@@ -33,6 +33,24 @@ public class StudentConverter {
   }
 
   /**
+   * 受講生リストとコース詳細情報リストから受講生詳細情報のリストに変換するconverterです。
+   * 受講生の内、studentIdで紐づくコース詳細情報が存在する場合のみStudentDetailに変換しリストに含めます。
+   */
+  public List<StudentDetail> toStudentDetailFromStudentsWithCourse(
+      List<Student> studentList, List<CourseDetail> courseDetailList) {
+
+    Map<Integer, List<CourseDetail>> coursesMap = courseDetailList.stream()
+        .collect(
+            Collectors.groupingBy(courseDetail -> courseDetail.getStudentCourse().getStudentId()));
+
+    return studentList.stream()
+        .filter(student -> coursesMap.containsKey(student.getStudentId()))
+        .map(student -> new StudentDetail(student,
+            coursesMap.getOrDefault(student.getStudentId(), List.of())))
+        .toList();
+  }
+
+  /**
    * 受講コースリストとコース申込ステータスリストからコース詳細情報のリストに変換するconverterです。
    * 両リストに同じcourseIdのデータが存在するレコードのみをコース詳細情報に変換しリストに含めます。
    */

--- a/src/main/java/raisetech/StudentManagement/service/formatter/SearchConditionFormatter.java
+++ b/src/main/java/raisetech/StudentManagement/service/formatter/SearchConditionFormatter.java
@@ -1,0 +1,35 @@
+package raisetech.StudentManagement.service.formatter;
+
+import java.text.Normalizer;
+import org.springframework.stereotype.Component;
+
+/**
+ * 検索条件SearchFormatterの各項目を検索可能な形式に変換するクラスです
+ */
+@Component
+public class SearchConditionFormatter {
+
+  /**
+   * カナ名の検索文字列について平仮名と半角カタカナを角カタカナに、またスペースはすべて半角に変換します。
+   */
+  public String kanaNameFormatter(String kanaName) {
+    if (kanaName == null || kanaName.isEmpty()) {
+      return kanaName;
+    }
+
+    // 半角 → 全角（スペースは半角）の正規化
+    String normalizedKanaName = Normalizer.normalize(kanaName, Normalizer.Form.NFKC);
+
+    // ひらがな → カタカナ
+    StringBuilder builder = new StringBuilder();
+    for (char c : normalizedKanaName.toCharArray()) {
+      if (c >= 'ぁ' && c <= 'ゖ') {
+        builder.append((char) (c + 0x60));
+      } else {
+        builder.append(c);
+      }
+    }
+
+    return builder.toString();
+  }
+}

--- a/src/main/resources/mapper/StudentRepository.xml
+++ b/src/main/resources/mapper/StudentRepository.xml
@@ -4,19 +4,55 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="raisetech.StudentManagement.repository.StudentRepository">
-  <!-- 全受講生の情報を取得（キャンセルは除外） -->
-  <select id="searchStudentList" resultType="raisetech.StudentManagement.data.Student">
-    SELECT * FROM students WHERE is_deleted = false
+  <!-- 検索条件に合致する受講生の情報を取得（キャンセルは除外） -->
+  <select id="searchStudentList"
+    parameterType="raisetech.StudentManagement.domain.condition.SearchCondition"
+    resultType="raisetech.StudentManagement.data.Student">
+    SELECT * FROM students
+    WHERE is_deleted = false
+    <if test="fullName != null and fullName != ''">
+      AND full_Name LIKE CONCAT('%', #{fullName}, '%')
+    </if>
+    <if test="kanaName != null and kanaName != ''">
+      AND kana_name LIKE CONCAT('%', #{kanaName}, '%')
+    </if>
+    <if test="email != null and email != ''">
+      AND email = #{email}
+    </if>
+    <if test="region != null and region != ''">
+      AND region LIKE CONCAT('%', #{region}, '%')
+    </if>
+    <if test="minAge != null">
+      AND age &gt;= #{minAge}
+    </if>
+    <if test="maxAge != null">
+      AND age &lt;= #{maxAge}
+    </if>
+    <if test="sex != null and sex != ''">
+      AND sex = #{sex}
+    </if>
   </select>
 
-  <!-- 全受講コース情報を取得 -->
-  <select id="searchStudentCourseList" resultType="raisetech.StudentManagement.data.StudentCourse">
+  <!-- 検索条件に合致する受講コース情報を取得 -->
+  <select id="searchStudentCourseList"
+    parameterType="raisetech.StudentManagement.domain.condition.SearchCondition"
+    resultType="raisetech.StudentManagement.data.StudentCourse">
     SELECT * FROM students_courses
+    WHERE 1 = 1
+    <if test="course != null and course != ''">
+      AND course LIKE CONCAT('%', #{course}, '%')
+    </if>
   </select>
 
-  <!-- 全コース申込ステータス情報を取得 -->
-  <select id="searchCourseStatusList" resultType="raisetech.StudentManagement.data.CourseStatus">
+  <!-- 検索条件に合致するコース申込ステータス情報を取得 -->
+  <select id="searchCourseStatusList"
+    parameterType="raisetech.StudentManagement.domain.condition.SearchCondition"
+    resultType="raisetech.StudentManagement.data.CourseStatus">
     SELECT * FROM course_status
+    WHERE 1 = 1
+    <if test="status != null and status != ''">
+      AND status = #{status}
+    </if>
   </select>
 
   <!-- PublicId による受講生情報の取得 -->

--- a/src/test/java/raisetech/StudentManagement/controller/SearchConditionValidationTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/SearchConditionValidationTest.java
@@ -1,0 +1,67 @@
+package raisetech.StudentManagement.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import raisetech.StudentManagement.domain.condition.SearchCondition;
+
+public class SearchConditionValidationTest {
+
+  @Autowired
+  private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+  //検索条件：正常系
+  @Test
+  void 検索条件の入力チェックで異常が発生しないこと() {
+    SearchCondition condition = SearchCondition.builder()
+        .fullName("太郎")
+        .kanaName("タロウ")
+        .email("tanaka@example.com")
+        .region("東京")
+        .minAge(18)
+        .maxAge(50)
+        .sex("男性")
+        .course("Javaコース")
+        .status("受講中")
+        .build();
+
+    Set<ConstraintViolation<SearchCondition>> violations = validator.validate(condition);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @ParameterizedTest
+  @MethodSource("searchConditionValidPattern")
+  void 検索条件のテストケースについて入力チェックで一つの異常が発生すること(
+      SearchCondition condition,
+      String message) {
+
+    Set<ConstraintViolation<SearchCondition>> violations = validator.validate(condition);
+
+    assertThat(violations.size()).isEqualTo(1);
+    assertThat(violations).extracting("message").contains(message);
+  }
+
+  private static Stream<Arguments> searchConditionValidPattern() {
+    return Stream.of(
+        Arguments.of(SearchCondition.builder().fullName("a".repeat(51)).build(),
+            "氏名の検索値は50文字以内で入力してください"),
+        Arguments.of(SearchCondition.builder().kanaName("田中").build(),
+            "カナ名の検索値は ひらがな・カタカナ、またはスペースのみを入力してください"),
+        Arguments.of(SearchCondition.builder().email("tanaka").build(),
+            "Emailは完全一致検索です。正しいメールアドレスの形式で入力してください"),
+        Arguments.of(SearchCondition.builder().maxAge(1500).build(),
+            "年齢の検索値は150以下で入力してください")
+    );
+  }
+
+}

--- a/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
@@ -1,5 +1,6 @@
 package raisetech.StudentManagement.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -11,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -21,6 +23,7 @@ import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
 import raisetech.StudentManagement.domain.CourseDetail;
 import raisetech.StudentManagement.domain.StudentDetail;
+import raisetech.StudentManagement.domain.condition.SearchCondition;
 import raisetech.StudentManagement.exception.converter.ErrorResponseConverter;
 import raisetech.StudentManagement.service.StudentService;
 import raisetech.StudentManagement.testdata.TestDataFactory;
@@ -40,14 +43,22 @@ class StudentControllerTest {
   @MockitoBean
   private ErrorResponseConverter errorResponseConverter;
 
-  //受講生全件検索：正常系
+  //受講生詳細条件検索：正常系
   @Test
-  void 受講生全件検索実行時に正常に処理が実行され適切なServiceが呼び出されていること()
+  void 受講生詳細条件検索実行時に正常に処理が実行され適切なServiceが呼び出されていること()
       throws Exception {
-    mockMvc.perform(get("/studentList"))
+    SearchCondition expected = SearchCondition.builder()
+        .fullName("田中")
+        .build();
+
+    mockMvc.perform(get("/studentList")
+            .param("fullName", "田中"))
         .andExpect(status().isOk());
 
-    verify(service, times(1)).searchStudentDetailList();
+    ArgumentCaptor<SearchCondition> captor = ArgumentCaptor.forClass(SearchCondition.class);
+
+    verify(service, times(1)).searchStudentDetailList(captor.capture());
+    assertThat(captor.getValue()).usingRecursiveComparison().isEqualTo(expected);
   }
 
   //受講生個人検索：正常系

--- a/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
@@ -93,7 +93,7 @@ class StudentServiceTest {
     verify(converter, times(1))
         .convertToCourseDetail(studentsCourseList, courseStatusList);
     verify(converter, times(1))
-        .convertToStudentDetail(studentList, courseDetailList);
+        .toStudentDetailFromAllStudents(studentList, courseDetailList);
     //repositoryの引数が変更後のconditionであることの検証
     List<SearchCondition> conditionList = captor.getAllValues();
     assertThat(conditionList)
@@ -123,7 +123,7 @@ class StudentServiceTest {
     verify(converter, times(1))
         .toStudentDetailFromStudentsWithCourse(studentList, courseDetailList);
     verify(converter, never())
-        .convertToStudentDetail(anyList(), anyList());
+        .toStudentDetailFromAllStudents(anyList(), anyList());
   }
 
   //受講生詳細条件検索：正常系:検索条件と合致する受講生なし

--- a/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import raisetech.StudentManagement.data.CourseStatus;
@@ -28,9 +29,11 @@ import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
 import raisetech.StudentManagement.domain.CourseDetail;
 import raisetech.StudentManagement.domain.StudentDetail;
+import raisetech.StudentManagement.domain.condition.SearchCondition;
 import raisetech.StudentManagement.exception.custom.NotUniqueException;
 import raisetech.StudentManagement.repository.StudentRepository;
 import raisetech.StudentManagement.service.converter.StudentConverter;
+import raisetech.StudentManagement.service.formatter.SearchConditionFormatter;
 
 @ExtendWith(MockitoExtension.class)
 class StudentServiceTest {
@@ -41,38 +44,149 @@ class StudentServiceTest {
   @Mock
   private StudentConverter converter;
 
+  @Mock
+  private SearchConditionFormatter formatter;
+
   private StudentService sut;
 
   private Student student;
 
   @BeforeEach
   void setUp() {
-    sut = new StudentService(repository, converter);
+    sut = new StudentService(repository, converter, formatter);
     student = new Student();
   }
 
-  //受講生全件検索：正常系
+  //受講生詳細条件検索：正常系:検索条件カナ名のみ
   @Test
-  void 受講生詳細情報の全件取得処理でrepositoryとconverterを適切に呼び出せていること() {
-    List<Student> studentList = new ArrayList<>();
+  void 受講生詳細条件検索で条件なしで検索した場合にrepositoryが正規化後の引数で適切に実行されかつ必要なconverterが呼び出されていること() {
+    //前準備
+    SearchCondition condition = SearchCondition.builder().kanaName("やまだ").build();
+    List<Student> studentList = List.of(student);
     List<StudentCourse> studentsCourseList = new ArrayList<>();
     List<CourseStatus> courseStatusList = new ArrayList<>();
     List<CourseDetail> courseDetailList = new ArrayList<>();
-    when(repository.searchStudentList()).thenReturn(studentList);
-    when(repository.searchStudentCourseList()).thenReturn(studentsCourseList);
-    when(repository.searchCourseStatusList()).thenReturn(courseStatusList);
+
+    String normalizedKanaName = "ヤマダ";
+
+    when(repository.searchStudentList(any(SearchCondition.class))).thenReturn(studentList);
+    when(repository.searchStudentCourseList(any(SearchCondition.class)))
+        .thenReturn(studentsCourseList);
+    when(repository.searchCourseStatusList(any(SearchCondition.class))).thenReturn(
+        courseStatusList);
     when(converter.convertToCourseDetail(studentsCourseList, courseStatusList))
         .thenReturn(courseDetailList);
+    when(formatter.kanaNameFormatter(condition.getKanaName())).thenReturn(normalizedKanaName);
 
-    sut.searchStudentDetailList();
+    //期待値
+    SearchCondition expectCondition = SearchCondition.builder().kanaName(normalizedKanaName)
+        .build();
 
-    verify(repository, times(1)).searchStudentList();
-    verify(repository, times(1)).searchStudentCourseList();
-    verify(repository, times(1)).searchCourseStatusList();
+    //実行
+    sut.searchStudentDetailList(condition);
+
+    //メソッド呼び出しの検証
+    ArgumentCaptor<SearchCondition> captor = ArgumentCaptor.forClass(SearchCondition.class);
+    verify(repository, times(1)).searchStudentList(captor.capture());
+    verify(repository, times(1)).searchStudentCourseList(captor.capture());
+    verify(repository, times(1)).searchCourseStatusList(captor.capture());
     verify(converter, times(1))
         .convertToCourseDetail(studentsCourseList, courseStatusList);
     verify(converter, times(1))
         .convertToStudentDetail(studentList, courseDetailList);
+    //repositoryの引数が変更後のconditionであることの検証
+    List<SearchCondition> conditionList = captor.getAllValues();
+    assertThat(conditionList)
+        .hasSize(3)
+        .allSatisfy(cr -> assertThat(cr.getKanaName()).isEqualTo(expectCondition.getKanaName()));
+  }
+
+  //受講生詳細条件検索：正常系:コース検索条件あり
+  @Test
+  void 受講生詳細条件検索でコース条件ありで検索した場合に早期リターンで適切なconverterを呼び出せていること() {
+    SearchCondition condition = SearchCondition.builder().course("Java").build();
+    List<Student> studentList = List.of(student);
+    List<StudentCourse> studentsCourseList = new ArrayList<>();
+    List<CourseStatus> courseStatusList = new ArrayList<>();
+    List<CourseDetail> courseDetailList = new ArrayList<>();
+
+    when(repository.searchStudentList(any(SearchCondition.class))).thenReturn(studentList);
+    when(repository.searchStudentCourseList(any(SearchCondition.class))).thenReturn(
+        studentsCourseList);
+    when(repository.searchCourseStatusList(any(SearchCondition.class))).thenReturn(
+        courseStatusList);
+    when(converter.convertToCourseDetail(studentsCourseList, courseStatusList))
+        .thenReturn(courseDetailList);
+
+    sut.searchStudentDetailList(condition);
+
+    verify(converter, times(1))
+        .toStudentDetailFromStudentsWithCourse(studentList, courseDetailList);
+    verify(converter, never())
+        .convertToStudentDetail(anyList(), anyList());
+  }
+
+  //受講生詳細条件検索：正常系:検索条件と合致する受講生なし
+  @Test
+  void 受講生詳細条件検索で条件に合致する受講生がいない場合に早期リターンで空リストが返されること() {
+    SearchCondition condition = SearchCondition.builder().build();
+    List<Student> studentList = List.of();
+
+    when(repository.searchStudentList(any(SearchCondition.class))).thenReturn(studentList);
+
+    List<StudentDetail> actual = sut.searchStudentDetailList(condition);
+
+    verify(repository, never()).searchStudentCourseList(any(SearchCondition.class));
+    assertThat(actual).isEmpty();
+  }
+
+  //検索条件正規化処理
+  @Test
+  void kanaNameのみが変換され他の値は保持されたconditionが返されること() {
+    //非変換項目
+    String fullName = "山田";
+    String email = "yamada@example.com";
+    String region = "東京都";
+    Integer minAge = 20;
+    Integer maxAge = 30;
+    String sex = "男性";
+    String course = "Java";
+    String status = "受講中";
+
+    //変換対象項目（変換前と変換後）
+    String beforeKanaName = "やまだ";
+    String afterKanaName = "ヤマダ";
+
+    SearchCondition condition = SearchCondition.builder()
+        .fullName(fullName)
+        .kanaName(beforeKanaName)  // 正規化対象
+        .email(email)
+        .region(region)
+        .minAge(minAge)
+        .maxAge(maxAge)
+        .sex(sex)
+        .course(course)
+        .status(status)
+        .build();
+
+    SearchCondition expected = SearchCondition.builder()
+        .fullName(fullName)
+        .kanaName(afterKanaName) // 正規化済み
+        .email(email)
+        .region(region)
+        .minAge(minAge)
+        .maxAge(maxAge)
+        .sex(sex)
+        .course(course)
+        .status(status)
+        .build();
+
+    when(formatter.kanaNameFormatter(condition.getKanaName())).thenReturn(afterKanaName);
+
+    SearchCondition actual = sut.SearchConditionFormatter(condition);
+
+    verify(formatter, times(1)).kanaNameFormatter(beforeKanaName);
+    assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
   }
 
   //受講生個人検索：正常系:studentに紐づくコース情報あり

--- a/src/test/java/raisetech/StudentManagement/service/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/converter/StudentConverterTest.java
@@ -94,6 +94,63 @@ class StudentConverterTest {
     assertThat(actual).isEmpty();
   }
 
+  //toStudentDetailFromStudentsWithCourse：データ組み替え検証
+  @Test
+  void リスト中の受講生で紐づくコース詳細情報が存在する場合のみStudentDetailを生成しリスト化できていること() {
+    //前準備
+    Student student888 = createStudentWithStudentId(888);
+    Student student999 = createStudentWithStudentId(999);
+
+    StudentCourse student888Course1 = createCourseWithStudentId(888);
+    StudentCourse student888Course2 = createCourseWithStudentId(888);
+    StudentCourse noiseCourse = createCourseWithStudentId(1999);
+
+    CourseDetail courseDetail888Course1 = new CourseDetail(student888Course1, new CourseStatus());
+    CourseDetail courseDetail888Course2 = new CourseDetail(student888Course2, new CourseStatus());
+    CourseDetail courseDetailNoiseCourse = new CourseDetail(noiseCourse, new CourseStatus());
+
+    List<Student> studentList = List.of(student888, student999);
+    List<CourseDetail> courseDetailList = List.of(courseDetail888Course1, courseDetail888Course2,
+        courseDetailNoiseCourse);
+
+    //期待値の設定
+    StudentDetail expectStudentDetail888 = new StudentDetail(student888,
+        List.of(courseDetail888Course1, courseDetail888Course2));
+
+    //実行
+    List<StudentDetail> actual = sut.toStudentDetailFromStudentsWithCourse(studentList,
+        courseDetailList);
+
+    //検証
+    assertThat(actual)
+        .hasSize(1)
+        .containsExactly(expectStudentDetail888);
+  }
+
+  @Test
+  void コース詳細情報リストが空の場合に空のリストが返されていること() {
+    List<Student> studentList = List.of(createStudentWithStudentId(999));
+    List<CourseDetail> courseDetailList = List.of();
+
+    List<StudentDetail> actual = sut.toStudentDetailFromStudentsWithCourse(studentList,
+        courseDetailList);
+
+    //検証
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void 受講生情報リストが空の場合に空のリストが返されていること() {
+    List<Student> studentList = List.of();
+    List<CourseDetail> courseDetailList = List.of(
+        new CourseDetail(createCourseWithStudentId(999), new CourseStatus()));
+
+    List<StudentDetail> actual = sut
+        .toStudentDetailFromStudentsWithCourse(studentList, courseDetailList);
+
+    assertThat(actual).isEmpty();
+  }
+
   //convertToCourseDetail:データの組み換え検証
   @Test
   void 受講コースとコース申込ステータスのリストから両リストに同じcourseID持つレコードのみをCourseDetailに変換しリスト化して返されること() {

--- a/src/test/java/raisetech/StudentManagement/service/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/converter/StudentConverterTest.java
@@ -20,9 +20,9 @@ class StudentConverterTest {
     sut = new StudentConverter();
   }
 
-  //convertToStudentDetail:データの組み換え検証
+  //toStudentDetailFromAllStudents:データの組み換え検証
   @Test
-  void 受講生リストと受講コース詳細リストからstudentIDに基づき適切なStudentDetailが返されること() {
+  void リスト中の全受講生に対し適切なコース詳細情報を割り当てたStudentDetailを生成しリスト化できていること() {
     //前準備
     Student student777 = createStudentWithStudentId(777);
     Student student888 = createStudentWithStudentId(888);
@@ -52,7 +52,7 @@ class StudentConverterTest {
         expectStudentDetail888, expectStudentDetail999);
 
     //実行
-    List<StudentDetail> actual = sut.convertToStudentDetail(studentList, courseDetailList);
+    List<StudentDetail> actual = sut.toStudentDetailFromAllStudents(studentList, courseDetailList);
 
     //検証
     assertThat(actual.size()).isEqualTo(expectStudentDetailList.size());
@@ -67,7 +67,7 @@ class StudentConverterTest {
 
     List<StudentDetail> expectStudentDetailList = List.of(new StudentDetail(student, List.of()));
 
-    List<StudentDetail> actual = sut.convertToStudentDetail(studentList, courseDetailList);
+    List<StudentDetail> actual = sut.toStudentDetailFromAllStudents(studentList, courseDetailList);
 
     assertThat(actual.size()).isEqualTo(expectStudentDetailList.size());
     assertThat(actual).isEqualTo(expectStudentDetailList);
@@ -79,7 +79,7 @@ class StudentConverterTest {
     List<CourseDetail> courseDetailList = List.of(
         new CourseDetail(createCourseWithStudentId(999), new CourseStatus()));
 
-    List<StudentDetail> actual = sut.convertToStudentDetail(studentList, courseDetailList);
+    List<StudentDetail> actual = sut.toStudentDetailFromAllStudents(studentList, courseDetailList);
 
     assertThat(actual).isEmpty();
   }
@@ -89,7 +89,7 @@ class StudentConverterTest {
     List<Student> studentList = List.of();
     List<CourseDetail> courseDetailList = List.of();
 
-    List<StudentDetail> actual = sut.convertToStudentDetail(studentList, courseDetailList);
+    List<StudentDetail> actual = sut.toStudentDetailFromAllStudents(studentList, courseDetailList);
 
     assertThat(actual).isEmpty();
   }

--- a/src/test/java/raisetech/StudentManagement/service/formatter/SearchConditionFormatterTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/formatter/SearchConditionFormatterTest.java
@@ -1,0 +1,47 @@
+package raisetech.StudentManagement.service.formatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SearchConditionFormatterTest {
+
+  private SearchConditionFormatter sut;
+
+  @BeforeEach
+  void setUp() {
+    sut = new SearchConditionFormatter();
+  }
+
+  @Test
+  void nullを渡すとnullが返ること() {
+    String actual = sut.kanaNameFormatter(null);
+    assertThat(actual).isNull();
+  }
+
+  @Test
+  void 半角カナは全角カナに正規化されること() {
+    String result = sut.kanaNameFormatter("ｶﾀｶﾅｱﾝ");
+    assertThat(result).isEqualTo("カタカナアン");
+  }
+
+  @Test
+  void ひらがなは全角カタカナに変換されること() {
+    String result = sut.kanaNameFormatter("ひらがなぁゖ");
+    assertThat(result).isEqualTo("ヒラガナァヶ");
+  }
+
+  @Test
+  void 全角カタカナと記号はそのまま返ること() {
+    String result = sut.kanaNameFormatter("カタカナァヶー");
+    assertThat(result).isEqualTo("カタカナァヶー");
+  }
+
+  @Test
+  void 全角スペースは半角スペースに変換されること() {
+    String result = sut.kanaNameFormatter("　 ");  //全角スペース1 + 半角スペース1
+    assertThat(result).isEqualTo("  ");
+  }
+
+}

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -8,8 +8,8 @@ INSERT INTO students (
 ('d8a0a2f1-7e5e-4f0f-b123-a1b3d1f82dd2', '佐藤 花子', 'サトウ ハナコ', '', 'hanako@example.com', '', NULL, '', '', FALSE),
 -- 最低限データ + NULLデータ
 ('e5f734ac-7c44-43e4-9aef-2dc1cb246aa1', '井上 翔', 'イノウエ ショウ', NULL, 'sho@example.com', NULL, NULL, NULL, NULL, FALSE),
-('c7f92318-bb9e-4a9b-908b-c5a8aaf3f378', '中村 悠', 'ナカムラ ユウ', 'ゆう', 'yuu@example.com', '北海道 札幌市', 22, '女性', 'Pythonとデータ分析に関心があります。統計や機械学習にも取り組みたいです。', FALSE),
-('b77c3c35-d43a-4f9e-bb7a-55871a6c2b7e', '鈴木 孝', 'スズキ タカシ', 'たかさん', 'takashi@example.com', '長野県 松本市', 100, 'その他', 'リスキリングとしてJavaを学習中', FALSE),
+('c7f92318-bb9e-4a9b-908b-c5a8aaf3f378', '中村 悠', 'ナカムラ ユウ', 'ゆう', 'yuu@example.com', '東京都 港区', 22, '女性', 'Pythonとデータ分析に関心があります。統計や機械学習にも取り組みたいです。', FALSE),
+('b77c3c35-d43a-4f9e-bb7a-55871a6c2b7e', '鈴木 太郎', 'スズキ タロウ', 'たかさん', 'suzuki@example.com', '長野県 松本市', 100, 'その他', 'リスキリングとしてJavaを学習中', FALSE),
 -- 論理削除=TRUE
 ('9a30b7b0-5e1b-4ac5-a7de-d2c3c1bfa382', '田中 太郎', 'タナカ タロウ', NULL, 'tanaka2@example.com', NULL, 40, '男性', 'すでに退会済の受講生', TRUE);
 --補足：studentId=2は更新処理のテスト対象として使用


### PR DESCRIPTION
44_検索条件の追加と申込み状況機能の追加
課題：
　申し込み状況機能の追加　（作成・提出済み）
　検索条件の追加　　　　　（本PR対象）

## 実装内容
全件検索機能を条件検索機能に改修しました。
（尚、条件なしの場合は全件取得と同等となるので、今まで同様の結果を得ることも可能です）
85067012ef76b03d0064153b429abe4204f4da65 ：受講生検索処理の実装（受講生全件検索を改修）
e9fb24108f0e6baf26e487b0a1e363d290ab02a1 ：converterのリファクタリング

### 詳細
### 受講生検索処理の実装
- **SearchCondition.class**：検索条件の項目を定義するクラスとして作成しました。
　　― ageは範囲検索できる様上限値・下限値の二つのfieldを持たせました。
　　ー カナ名はプログラム内でカナ変換する仕様とし、下記文字種のみ許容します。
　　　　ひらがな、カタカナ、半角カタカナ、ー、スペース
　　※未実装：年齢上下限は下限値＞上限値のカスタムバリデーションを検討しましたが未実装です。
　　　（必要に応じ実装を検討。 現状、下限値＞上限値では条件合致値がないため結果なしで空リストが返されます）

- **Controller** ：全件検索メソッドを条件検索メソッドに改修

- **Service**：全件検索メソッドを条件検索メソッドに改修
　　－検索条件は、SearchConditionFormatterにて正規化（カナ名のみ正規化対応）

- **Converter**：条件検索対応の新規のStudentDetailconverterを実装。
　　ー新規のStudentDetailのconverterは受講生に紐づくコース情報がある場合のみStudnetDetailを作成
　　　　→受講コースと申込状況の検索条件が**ある**場合はコース情報は必須であり新converterを適用
　　※従来のStudentDetailのconverterはコース詳細の空を許容し全受講生に対しStudentDetailを作成
　　　　→受講コースと申込状況の検索条件が**ない**場合は従来converterを適用しコース詳細の空を許容

- ** SearchConditionFormatter ** ：検索条件を、検索処理が可能な形式に変換する処理をまとめたクラスを追加
　　－カナ名の検索値を全角カナ/半角スペースに変換する処理を導入
 　　　（現在DBのカナ名の登録値の氏・名間は半角スペースなのでその様式に合わせた変換になっています）
　　　※本来は登録時に文字種に制限をかけるべきなので別途対応予定です

- **Repository**：全件検索の各種メソッドを条件検索メソッドに改修

- メインの各クラス変更に伴い、各対応クラスのテストの修正・追加
　　― Controllerテスト：修正のみ
　　－ Serviceテスト：変更前/全件検索正常系テスト（計１パターン）
　　　　　　　　　　　→　変更後/ルート別に正常系テスト追加（計3パターン）
　　－ Repositoryテスト：各検索条件の単独条件検索テスト ＋ 年齢上下限の複数条件検索テスト
　　－ Converterテスト：追加メソッドのテスト追加（両リストあり、コースリスト空、申込状況リスト空の3種）

- SearchConditionFormatterのテストクラスの追加（各変換パターンで変換できているか検証）

- SearchConditionのバリデーションテストクラスの追加（代表的なバリデーションについて検証）

**converterのリファクタリング**
- 新規converterのメソッド名や処理内容に対し、従来converterメソッドを区別できるようにメソッド名およびテスト名を修正しました。

補足：
・DBの設定により、検索で小文字大文字は区別されません。

**確認事項**　
①Serviceのテストについて： 
上記リンク箇所のテストについて、確認いただきたい内容記載しています。
テストの方法が問題ないかご確認ご回答いただけますと幸いです。

## 実行確認
### ポストマン実行結果
- 条件なし検索結果（全件取得）
<img width="1478" height="4158" alt="image" src="https://github.com/user-attachments/assets/50389509-5c97-434a-b7b0-8d670b4b7dbf" />


- 氏名検索（条件：山本）
<img width="549" height="836" alt="image" src="https://github.com/user-attachments/assets/66106f06-f505-4309-a1e7-798de7b97dea" />


- カナ名検索（条件：はなこ)
<img width="534" height="2345" alt="image" src="https://github.com/user-attachments/assets/d3548eaf-6f2f-49a1-9cc1-a0b46b94ee4f" />


- 年齢検索（条件：下限=30 上限=39）
<img width="528" height="1099" alt="image" src="https://github.com/user-attachments/assets/192402a3-1521-4fb9-a40f-77f94868154e" />


- コース検索（条件：aws）
<img width="558" height="1427" alt="image" src="https://github.com/user-attachments/assets/88bd993f-8355-4847-9bd5-2ee0bfcfa65b" />


- 申込ステータス検索（条件：キャンセル）
<img width="523" height="1423" alt="image" src="https://github.com/user-attachments/assets/163b32c7-f96d-4982-be2f-eec13239d773" />


**補足：**
テーブル設定（COLLATE）の確認

　受講生（publicId 以外 utf8mb4_general_ci で大文字小文字は区別されない）
<img width="774" height="338" alt="image" src="https://github.com/user-attachments/assets/57cd86f4-96d3-4bac-8eb2-96f4f48f1174" />
　
　受講コース
<img width="921" height="218" alt="スクリーンショット 2025-07-18 152747" src="https://github.com/user-attachments/assets/5fb25557-2afa-4626-b39f-6dda43a4d923" />
　
　申込ステータス
<img width="950" height="251" alt="image" src="https://github.com/user-attachments/assets/4b151693-03ba-49de-97ab-0998dc818c6e" />

### API仕様書
条件検索処理
<img width="1503" height="2660" alt="image" src="https://github.com/user-attachments/assets/e4e387f0-a9ae-418d-8c93-4fac97743f8d" />


### テスト結果
- controllerテスト
<img width="991" height="203" alt="image" src="https://github.com/user-attachments/assets/1bfcbfdc-77e0-41c5-b47b-23bd8447d651" />

- searchConditionバリデーションテスト
<img width="985" height="214" alt="image" src="https://github.com/user-attachments/assets/0ff01df5-82ee-4cbd-9c61-c8f227def5c6" />

- serviceテスト
<img width="1034" height="447" alt="image" src="https://github.com/user-attachments/assets/3ec73157-6378-4b60-bcf5-b775a1620847" />

- converterテスト
<img width="968" height="321" alt="image" src="https://github.com/user-attachments/assets/2d3ca5fc-de1e-48ea-9c39-a3c04cb9909a" />

- conditionFormatterテスト
<img width="1012" height="277" alt="image" src="https://github.com/user-attachments/assets/e45478bc-d3d9-49b4-8ded-6b93267e5918" />

- repositoryテスト
<img width="1003" height="835" alt="image" src="https://github.com/user-attachments/assets/bc1fa311-1312-4959-89a2-fec371bb3049" />


